### PR TITLE
refactor: improve handlebars usage

### DIFF
--- a/js/database/summarize-trend-data.js
+++ b/js/database/summarize-trend-data.js
@@ -34,7 +34,6 @@ function summarizeTrendData(p1stats, p2stats) {
       // general win loss pop stats
       const win = {
         heroName,
-        heroImg: Heroes.heroIcon(heroName),
         winPercent: hero.games === 0 ? 0 : hero.wins / hero.games,
         banPercent: hero.bans.total / data.totalMatches,
         popPercent: hero.involved / data.totalMatches,
@@ -50,7 +49,6 @@ function summarizeTrendData(p1stats, p2stats) {
         format: {},
         games: hero.games,
         heroName,
-        heroImg: win.heroImg,
         heroRole: win.heroRole,
         winPercent: win.winPercent,
         banPercent: win.banPercent,
@@ -78,7 +76,6 @@ function summarizeTrendData(p1stats, p2stats) {
 
     const context = {
       heroName,
-      heroImg: Heroes.heroIcon(heroName),
       heroRole: Heroes.role(heroName),
       period1: aggr[heroName].period1 || {
         win: {

--- a/js/hero-collection.js
+++ b/js/hero-collection.js
@@ -299,19 +299,7 @@ function loadOverallHeroCollectionData() {
 function toggleHeroCollectionType(tableID, active, container) {
   let type = active.text();
   let elem = $(container).find('.button.' + type);
-
-  if (type === "Assassin") {
-    elem.toggleClass('red');
-  } else if (type === "Warrior") {
-    elem.toggleClass('blue');
-  } else if (type === "Support") {
-    elem.toggleClass('teal');
-  } else if (type === "Specialist") {
-    elem.toggleClass('violet');
-  } else if (type === "Multiclass") {
-    elem.toggleClass('purple');
-  }
-
+  elem.toggleClass(RoleColorClass[type]);
   $(tableID + ' table').find('.' + type).toggleClass('is-hidden');
 }
 
@@ -409,24 +397,17 @@ function renderHeroCollectionVsStatsTo(container, stats, threshold, avg) {
 }
 
 function getCompositionElement(roles) {
-  let elem = '<div class="ui five column grid comp-grid">';
+  const template = getHandlebars("hero-collection", "#hero-composition");
 
-  for (let r of roles) {
-    elem += '<div class="column">';
-    elem += '<div class="ui mini image">';
-    elem += '<div class="ui small ' + RoleColorClass[r] + ' ribbon label">' + r + '</div>';
+  const context = {
+    roles: roles.map((r) => ({
+      name: r,
+      colorClass: RoleColorClass[r],
+      image: r === 'Multiclass' ? 'specialist' : r.toLowerCase()
+    }))
+  };
 
-    if (r === 'Multiclass') {
-      elem += '<img src="assets/images/role_specialist.png">'
-    }
-    else {
-      elem += '<img src="assets/images/role_' + r.toLowerCase() + '.png">';
-    }
-    elem += '</div></div>'
-  }
-
-  elem += '</div>';
-  return elem;
+  return template(context);
 }
 
 function layoutHeroCollectionPrint(sections) {

--- a/js/hero-collection.js
+++ b/js/hero-collection.js
@@ -17,12 +17,9 @@ function initHeroCollectionPage() {
     mode: { $in: [ReplayTypes.GameMode.UnrankedDraft, ReplayTypes.GameMode.HeroLeague, ReplayTypes.GameMode.TeamLeague, ReplayTypes.GameMode.Custom]}
   }
 
-  heroCollectionSummaryRowTemplate = Handlebars.compile(getTemplate('hero-collection', '#hero-collection-hero-summary-row-template').
-    find('.hero-collection-hero-summary-row')[0].outerHTML);
-  heroCollectionPickRowTemplate = Handlebars.compile(getTemplate('hero-collection', '#hero-collection-hero-pick-row-template').
-    find('.hero-collection-hero-summary-row')[0].outerHTML);
-  heroCollectionHeroWinRowTemplate = Handlebars.compile(getTemplate('hero-collection', '#hero-collection-detail-hero-win-row').
-    find('tr')[0].outerHTML);
+  heroCollectionSummaryRowTemplate = getHandlebars('hero-collection', '#hero-collection-hero-summary-row-template');
+  heroCollectionPickRowTemplate = getHandlebars('hero-collection', '#hero-collection-hero-pick-row-template');
+  heroCollectionHeroWinRowTemplate = getHandlebars('hero-collection', '#hero-collection-detail-hero-win-row');
 
   $('#hero-collection-summary table').tablesort();
   $('#hero-collection-picks table').tablesort();
@@ -56,7 +53,7 @@ function initHeroCollectionPage() {
   });
 
   // filter popup
-  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template').find('.filter-popup-widget')[0].outerHTML);
+  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template'));
   filterWidget.attr('widget-name', 'hero-collection-filter');
 
   $('#filter-widget').append(filterWidget);
@@ -301,61 +298,21 @@ function loadOverallHeroCollectionData() {
 
 function toggleHeroCollectionType(tableID, active, container) {
   let type = active.text();
-  let hide = false;
   let elem = $(container).find('.button.' + type);
 
   if (type === "Assassin") {
-    if (active.hasClass('red')) {
-      hide = true;
-      elem.removeClass('red');
-    }
-    else {
-      elem.addClass('red');
-    }
-  }
-  if (type === "Warrior") {
-    if (active.hasClass('blue')) {
-      hide = true;
-      elem.removeClass('blue');
-    }
-    else {
-      elem.addClass('blue');
-    }
-  }
-  if (type === "Support") {
-    if (active.hasClass('teal')) {
-      hide = true;
-      elem.removeClass('teal');
-    }
-    else {
-      elem.addClass('teal');
-    }
-  }
-  if (type === "Specialist") {
-    if (active.hasClass('violet')) {
-      hide = true;
-      elem.removeClass('violet');
-    }
-    else {
-      elem.addClass('violet');
-    }
-  }
-  if (type === "Multiclass") {
-    if (active.hasClass('purple')) {
-      hide = true;
-      elem.removeClass('purple');
-    }
-    else {
-      elem.addClass('purple');
-    }
+    elem.toggleClass('red');
+  } else if (type === "Warrior") {
+    elem.toggleClass('blue');
+  } else if (type === "Support") {
+    elem.toggleClass('teal');
+  } else if (type === "Specialist") {
+    elem.toggleClass('violet');
+  } else if (type === "Multiclass") {
+    elem.toggleClass('purple');
   }
 
-  if (hide) {
-    $(tableID + ' table').find('.' + type).addClass('is-hidden');
-  }
-  else {
-    $(tableID + ' table').find('.' + type).removeClass('is-hidden');
-  }
+  $(tableID + ' table').find('.' + type).toggleClass('is-hidden');
 }
 
 // many of the functions here are borrowed from player.js

--- a/js/hero-collection.js
+++ b/js/hero-collection.js
@@ -195,7 +195,6 @@ function loadOverallHeroCollectionData() {
 
       let context = {};
       context.heroName = h;
-      context.heroImg = Heroes.heroIcon(h);
       context.winPercent = hero.games === 0 ? 0 : hero.wins / hero.games;
       context.formatWinPercent = formatStat('pct', context.winPercent);
       context.banPercent = hero.bans.total / overallStats.totalMatches;
@@ -214,7 +213,6 @@ function loadOverallHeroCollectionData() {
       banContext.format = {};
       banContext.games = hero.games;
       banContext.heroName = h;
-      banContext.heroImg = context.heroImg;
       banContext.heroRole = context.heroRole;
       banContext.winPercent = context.winPercent;
       banContext.format.winPercent = context.formatWinPercent;
@@ -379,7 +377,6 @@ function renderHeroCollectionVsStatsTo(container, stats, threshold, avg) {
       context.winPercent = context.wins / context.games;
     }
     context.formatWinPercent = formatStat('pct', context.winPercent);
-    context.heroImg = Heroes.heroIcon(context.name);
 
     if (h in avg.heroData.heroes) {
       context.avgDelta = context.winPercent - (avg.heroData.heroes[h].wins / avg.heroData.heroes[h].games);

--- a/js/hero-trends.js
+++ b/js/hero-trends.js
@@ -19,9 +19,9 @@ function initTrendsPage() {
     mode: { $in: [ReplayTypes.GameMode.UnrankedDraft, ReplayTypes.GameMode.HeroLeague, ReplayTypes.GameMode.TeamLeague, ReplayTypes.GameMode.Custom]}
   }
 
-  trendsOverallHeroRowTemplate = Handlebars.compile(getTemplate('trends', '#trends-hero-summary-row-template').find('tr')[0].outerHTML);
-  trendsHeroPickTemplate = Handlebars.compile(getTemplate('trends', '#trends-hero-pick-row-template').find('tr')[0].outerHTML);
-  trendsHeroBanTemplate = Handlebars.compile(getTemplate('trends', '#trends-hero-pick-ban-template').find('tr')[0].outerHTML);
+  trendsOverallHeroRowTemplate = getHandlebars('trends', '#trends-hero-summary-row-template');
+  trendsHeroPickTemplate = getHandlebars('trends', '#trends-hero-pick-row-template');
+  trendsHeroBanTemplate = getHandlebars('trends', '#trends-hero-pick-ban-template');
 
   //tables
   $('#hero-trends-body table').tablesort();
@@ -34,7 +34,7 @@ function initTrendsPage() {
   });
 
   // filter
-  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template').find('.filter-popup-widget')[0].outerHTML);
+  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template'));
   filterWidget.attr('widget-name', 'hero-trends-filter');
 
   $('#filter-widget').append(filterWidget);
@@ -136,18 +136,15 @@ function loadTrends() {
 
   DB.getMatches(query1, function(err, dp1) {
     DB.getMatches(query2, function(err, dp2) {
-      $('#hero-trends-body tbody').html('');
-
       let p1stats = summarizeMatchData(dp1, Heroes);
       let p2stats = summarizeMatchData(dp2, Heroes);
 
       const { hContext, comps } = summarizeTrendData(p1stats, p2stats);
 
-      for (let context of hContext) {
-        $('#hero-trends-summary tbody').append(trendsOverallHeroRowTemplate(context));
-        $('#hero-trends-picks tbody').append(trendsHeroPickTemplate(context));
-        $('#hero-trends-bans tbody').append(trendsHeroBanTemplate(context));
-      }
+      $('#hero-trends-body tbody').html('');
+      $('#hero-trends-summary tbody').append(trendsOverallHeroRowTemplate({ context: hContext }));
+      $('#hero-trends-picks tbody').append(trendsHeroPickTemplate({context: hContext}));
+      $('#hero-trends-bans tbody').append(trendsHeroBanTemplate({context: hContext}));
 
       for (let c in comps) {
         let comp = comps[c];

--- a/js/index.js
+++ b/js/index.js
@@ -45,6 +45,7 @@ Handlebars.registerHelper('formatSeconds', formatSeconds);
 Handlebars.registerHelper('formatPct', (value) => formatStat('pct', value));
 Handlebars.registerHelper('formatKDA', (value) => formatStat('KDA', value));
 Handlebars.registerHelper('formatDelta', formatDelta);
+Handlebars.registerHelper('heroImage', (name) => `assets/heroes-talents/images/heroes/${Heroes.heroIcon(name)}`);
 
 // datepicker gloabl settings
 $.fn.datepicker.setDefaults({

--- a/js/index.js
+++ b/js/index.js
@@ -277,13 +277,14 @@ function loadSections() {
   changeSection('matches');
 }
 
+
+const getHandlebars = require('./js/util/handlebars');
+
+
 // returns the template contained in an import
 function getTemplate(name, selector) {
-  let link = document.querySelector('link[name="'+ name + '"]');
-  let template = link.import.querySelector(selector);
-  let clone = $(document.importNode(template.content, true));
-
-  return clone;
+  const link = document.querySelector('link[name="'+ name + '"]');
+  return link.import.querySelector(selector).innerHTML;
 }
 
 function createBGWindow() {

--- a/js/maps.js
+++ b/js/maps.js
@@ -5,7 +5,7 @@ var mapsMapRowTemplate;
 function initMapsPage() {
 
   // templates
-  mapsMapRowTemplate = Handlebars.compile(getTemplate('maps', '#map-table-row-template').find('tr')[0].outerHTML);
+  mapsMapRowTemplate = getHandlebars('maps', '#map-table-row-template');
 
   // tables
   $('#maps-page-content table').tablesort();
@@ -18,7 +18,7 @@ function initMapsPage() {
   });
 
   // filter popup
-  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template').find('.filter-popup-widget')[0].outerHTML);
+  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template'));
   filterWidget.attr('widget-name', 'maps-filter');
 
   $('#filter-widget').append(filterWidget);

--- a/js/match-detail.js
+++ b/js/match-detail.js
@@ -654,7 +654,6 @@ function appendSummaryRow(color, id) {
   let context = {};
   context.teamColor = color;
   context.heroName = data.hero;
-  context.heroImg = Heroes.heroIcon(data.hero);
   context.playerID = id;
   context.playerName = data.name + (data.tag ? '#' + data.tag : '');
   context.kills = data.gameStats.SoloKill;
@@ -685,7 +684,6 @@ function appendDetailHeader(color, id) {
   context.playerID = id;
   context.playerName = data.name;
   context.teamColor = color;
-  context.heroImg = Heroes.heroIcon(data.hero);
 
   $('#match-detail-details table thead tr').append(matchDetailHeaderTemplate(context));
 }
@@ -734,7 +732,6 @@ function appendTalentRow(color, id) {
   let titleContext = {};
   titleContext.teamColor = color;
   titleContext.playerID = id;
-  titleContext.heroImg = Heroes.heroIcon(data.hero);
   titleContext.heroName = data.hero;
   titleContext.playerName = data.name;
 
@@ -772,8 +769,8 @@ function loadChat() {
 
       if (msg.player in matchDetailPlayers) {
         context.playerName = matchDetailPlayers[msg.player].name;
+        context.heroName = matchDetailPlayers[msg.player].hero;
         context.showImg = '';
-        context.heroImg = Heroes.heroIcon(matchDetailPlayers[msg.player].hero);
       }
       else {
         context.showImg = 'is-hidden';

--- a/js/match-detail.js
+++ b/js/match-detail.js
@@ -304,13 +304,13 @@ function initMatchDetailPage() {
   $('#match-detail-submenu .item').tab();
 
   // templates
-  matchSummaryRowTemplate = Handlebars.compile(getTemplate('match-detail', '#match-detail-summary-row-template').find('tr')[0].outerHTML);
-  matchDetailHeaderTemplate = Handlebars.compile(getTemplate('match-detail', '#match-detail-detail-header').find('th')[0].outerHTML);
+  matchSummaryRowTemplate = getHandlebars('match-detail', '#match-detail-summary-row-template');
+  matchDetailHeaderTemplate = getHandlebars('match-detail', '#match-detail-detail-header');
   matchDetailRowTemplate = Handlebars.compile(matchDetailRowTemplateSrc);
-  matchTalentRowTitleTemplate = Handlebars.compile(getTemplate('match-detail', '#match-detail-talents-row-title-template').find('tr')[0].outerHTML);
-  matchTalentRowCellTemplate = Handlebars.compile(getTemplate('match-detail', '#match-detail-talents-row-cell-template').find('td')[0].outerHTML);
-  matchChatEntryTemplate = Handlebars.compile(getTemplate('match-detail', '#match-detail-chat-log-entry').find('div.event')[0].outerHTML);
-  matchTauntEntryTemplate = Handlebars.compile(getTemplate('match-detail', '#match-detail-taunt-entry').find('tr')[0].outerHTML);
+  matchTalentRowTitleTemplate = getHandlebars('match-detail', '#match-detail-talents-row-title-template');
+  matchTalentRowCellTemplate = getHandlebars('match-detail', '#match-detail-talents-row-cell-template');
+  matchChatEntryTemplate = getHandlebars('match-detail', '#match-detail-chat-log-entry');
+  matchTauntEntryTemplate = getHandlebars('match-detail', '#match-detail-taunt-entry');
 
   $('#match-detail-taunt-table').tablesort();
   $('#match-detail-taunt-table').floatThead({
@@ -328,7 +328,7 @@ function initMatchDetailPage() {
     $('#match-detail-taunt-table').floatThead('reflow');
   });
 
-  
+
   redTeamXPGraphData = {
     type: 'line',
     data: {},
@@ -362,11 +362,11 @@ function initMatchDetailPage() {
   $('#match-detail-timeline-buttons .button').click(function() {
     toggleGroup(parseInt($(this).attr('button-id')));
   });
-  
+
   $('#match-detail-teams').dropdown({
     action: 'hide',
     onChange: function(value, text, $elem) {
-      matchDetailTeamAction(value); 
+      matchDetailTeamAction(value);
     }
   });
 
@@ -495,7 +495,7 @@ function loadMatch(docs, doneLoadCallback) {
 
   // load xp
   graphXP();
-  
+
   // load chat
   loadChat();
 
@@ -534,7 +534,7 @@ function updateBasicInfo() {
   }
 
   $('#match-detail-mode').text(ReplayTypes.GameModeStrings[matchDetailMatch.mode]);
-  let d = new Date(matchDetailMatch.date); 
+  let d = new Date(matchDetailMatch.date);
   $('#match-detail-date').text(d.toLocaleString('en-US'));
   $('#match-detail-file').text(matchDetailMatch.filename);
   $('#match-detail-blue-level').text(matchDetailMatch.teams[0].level);
@@ -769,7 +769,7 @@ function loadChat() {
     if ('text' in msg) {
       let context = { message: msg.text };
       context.time = formatSeconds(msg.time);
-      
+
       if (msg.player in matchDetailPlayers) {
         context.playerName = matchDetailPlayers[msg.player].name;
         context.showImg = '';
@@ -827,7 +827,7 @@ function addTauntEntry(type, player, data) {
   $('#match-detail-taunt-table tbody').append(matchTauntEntryTemplate(context));
 }
 
-// takes the total of all the xp values 
+// takes the total of all the xp values
 function graphXP() {
   let team0XP = getTotalXPSet(0);
   let team1XP = getTotalXPSet(1);
@@ -872,7 +872,7 @@ function getTotalXPSet(teamID) {
     let x = matchDetailMatch.XPBreakdown[xp];
 
     if (x.team === teamID) {
-      // we want the total here. 
+      // we want the total here.
       let y = x.breakdown.CreepXP + x.breakdown.HeroXP + x.breakdown.MinionXP + x.breakdown.StructureXP + x.breakdown.TrickleXP
       data.push({x: x.time, y: parseInt(y) });
     }
@@ -889,7 +889,7 @@ function getLevelsXPSet(teamID) {
     let level = levels[l];
     if (level.level === 1)
       continue;
-    
+
     data.push({ x: level.time, y: level.level });
   }
 
@@ -1057,7 +1057,7 @@ function loadTimeline() {
       return 0;
     if (a.time < b.time)
       return -1;
-    
+
     return 1;
   });
   let start = 0;
@@ -1080,7 +1080,7 @@ function loadTimeline() {
       let item = {};
       item.start = start;
       item.end = event.time;
-      
+
       if (currentLevelDiff === 0) {
         item.content = "0";
       }
@@ -1151,7 +1151,7 @@ function loadTimeline() {
     let item = {};
     item.start = merc.time;
     item.content = merc.type;
-    
+
     if (merc.team === 0) {
       item.className = 'blue';
     }
@@ -1200,7 +1200,7 @@ function loadTimeline() {
   }
   else if (matchDetailMatch.map === ReplayTypes.MapType.HauntedMines) {
     getMinesEvents(items);
-  } 
+  }
   else if (matchDetailMatch.map === ReplayTypes.MapType.BattlefieldOfEternity) {
     getBOEEvents(items);
   }
@@ -1252,7 +1252,7 @@ function loadTimeline() {
   matchDetailTimeline = new vis.Timeline($('#match-detail-timeline-wrapper')[0], new vis.DataSet(items), matchDetailTimelineGroups, opts);
   matchDetailTimeline.on('rangechanged', function(props) {
     $('.timeline-popup').popup();
-  }); 
+  });
   matchDetailTimelineGroups.on('update', function() {
     matchDetailTimeline.redraw();
   });
@@ -1281,7 +1281,7 @@ function generateTDTimeline(data) {
   pop += formatSeconds(data.time) + "</div></div></h3>";
   pop += "<h3 class='ui header second'>Killed By</h3>";
   pop += "<div class='ui mini circular images'>";
-  
+
   for (let a in data.killers) {
     let k = data.killers[a];
     pop += "<img class='ui image' src='assets/heroes-talents/images/heroes/" + Heroes.heroIcon(k.hero) + "'>";
@@ -1391,7 +1391,7 @@ function getGardenEvents(items) {
       item.group = 5;
 
       let hero = matchDetailMatch.teams[t].heroes[matchDetailMatch.teams[t].ids.indexOf(terror.player)];
-      
+
       let pop = "<h3 class='ui image header'>";
       pop += "<img src='assets/heroes-talents/images/heroes/" + Heroes.heroIcon(hero) + "' class='ui large circular image'>";
       pop += "<div class='content'>Garden Terror<div class='sub header'>Spawned at: " + formatSeconds(item.start) + ", Duration: " + formatSeconds(terror.duration);
@@ -1488,7 +1488,7 @@ function getMinesEvents(items) {
       item.end = golem.endTime;
       item.group = 5;
       item.className = golem.team === 0 ? 'blue' : 'red';
-      
+
       let pop = "<h3 class='ui header'><div class='content'>Grave Golem<div class='sub header'>Spawn: " + formatSeconds(golem.startTime);
       pop += ", Duration: " + formatSeconds(golem.duration) + "</div></div></h3>";
 
@@ -1653,7 +1653,7 @@ function getShrinesEvents(items) {
       pop += "<div class='sub header'>Spawn: " + formatSeconds(item.start) + ", Duration: " + formatSeconds(punisher.duration);
       pop += "</div></div></h3>";
       pop += "<p>Siege Damage: " + parseInt(punisher.siegeDamage) + "<br>Hero Damage: " + parseInt(punisher.heroDamage) + "</p>";
-      
+
       item.content = '<div class="timeline-popup" data-variation="wide" data-html="' + pop + '">'
       item.content += punisher.type.substr(0, punisher.type.length - 6) + ' Punisher</div>';
       items.push(item);
@@ -1671,11 +1671,11 @@ function getTombEvents(items) {
       item.end = spider.end;
       item.group = 5;
       item.className = spider.team === 0 ? 'blue' : 'red';
-  
+
       let pop = "<h3 class='ui header'><div class='content'>Webweavers";
       pop += "<div class='sub header'>Spawn: " + formatSeconds(item.start) + ", Duration: " + formatSeconds(spider.duration);
       pop += "</div></div></h3>";
-  
+
       item.content = '<div class="timeline-popup" data-variation="wide" data-html="' + pop + '">Webweavers</div>';
       items.push(item);
     }
@@ -1700,7 +1700,7 @@ function getVolskayaEvents(items) {
      item.content = '<div class="timeline-popup" data-variation="wide" data-html="' + pop + '">Triglav</div>';
      items.push(item);
    }
- } 
+ }
 }
 
 function getWarheadEvents(items) {
@@ -1712,7 +1712,7 @@ function getWarheadEvents(items) {
       item.start = nuke.time;
       item.group = 5;
       item.className = nuke.team === 0 ? 'blue' : 'red';
-      
+
       let hero = matchDetailMatch.teams[t].heroes[matchDetailMatch.teams[t].ids.indexOf(nuke.player)];
       let pop = "<h3 class='ui image header'>";
       pop += "<img src='assets/heroes-talents/images/heroes/" + Heroes.heroIcon(hero) + "' class='ui large circular image'>";
@@ -1918,7 +1918,7 @@ function drawTeamStatGraphs() {
       if (p.team === 0) {
         color = blueColors[blueCt];
         blueCt += 1;
-      } 
+      }
       else {
         color = redColors[redCt];
         redCt += 1;
@@ -2104,7 +2104,7 @@ function matchDetailCollectionAction(value, text, $elem) {
   if (value ==='add') {
     $('#matches-collection-select .header').text('Add Current Match To Collection')
     $('#matches-collection-select p.text').text('Add the current match to the spcified collection. Matches can be added to multiple collections.');
-  
+
     $('#matches-collection-select').modal({
       onApprove: function() {
         let collectionID = $('#matches-collection-select .collection-menu').dropdown('get value');
@@ -2123,7 +2123,7 @@ function matchDetailCollectionAction(value, text, $elem) {
   else if (value === 'remove') {
     $('#matches-collection-select .header').text('Remove Current Match From Collection')
     $('#matches-collection-select p.text').text('Remove the current match from the spcified collection.');
-  
+
     $('#matches-collection-select').modal({
       onApprove: function() {
         let collectionID = $('#matches-collection-select .collection-menu').dropdown('get value');
@@ -2244,7 +2244,7 @@ function layoutMatchDetailPrint(sections) {
     addPrintSubHeader('Talents', 'talents');
     copyFloatingTable($('#match-detail-talents'), getPrintPage('talents'));
   }
-  
+
   if (sects.indexOf('team-stats') !== -1) {
     addPrintPage('team-stats');
     addPrintSubHeader('Team Stats', 'team-stats');
@@ -2255,7 +2255,7 @@ function layoutMatchDetailPrint(sections) {
   if (sects.indexOf('graphs') !== -1) {
     addPrintPage('graphs');
     addPrintSubHeader('Stats', 'graphs');
-    
+
     getPrintPage('graphs').append($('#match-detail-team-numbers').clone());
     copyGraph(teamOverallStatGraphData, $('#print-window #match-detail-team-numbers'), { width: 1650, height: 650 });
 
@@ -2278,7 +2278,7 @@ function layoutMatchDetailPrint(sections) {
     addPrintPage('xp');
     addPrintSubHeader('XP Graphs', 'xp');
     $('#print-window .contents .xp.page').append('<div class="ui two column grid xp-graphs"></div>');
-    
+
     $('#print-window .xp-graphs').append('<div class="column xp-vs-time"><h3 class="ui dividing header">XP vs Time</h3><canvas></div>')
     copyGraph(overallXPGraphData, $('#print-window .xp-vs-time canvas'), { width: 700, height: 400 });
 

--- a/js/matches.js
+++ b/js/matches.js
@@ -483,10 +483,10 @@ function renderToSlot(gameData, slot) {
     context.hideBans = 'is-hidden';
   }
   else {
-    context.bban1Img = Heroes.heroIcon(Heroes.heroNameFromAttr(gameData.bans[0][0].hero));
-    context.bban2Img = Heroes.heroIcon(Heroes.heroNameFromAttr(gameData.bans[0][1].hero));
-    context.rban1Img = Heroes.heroIcon(Heroes.heroNameFromAttr(gameData.bans[1][0].hero));
-    context.rban2Img = Heroes.heroIcon(Heroes.heroNameFromAttr(gameData.bans[1][1].hero));
+    context.bban1Hero = Heroes.heroNameFromAttr(gameData.bans[0][0].hero);
+    context.bban2Hero = Heroes.heroNameFromAttr(gameData.bans[0][1].hero);
+    context.rban1Hero = Heroes.heroNameFromAttr(gameData.bans[1][0].hero);
+    context.rban2Hero = Heroes.heroNameFromAttr(gameData.bans[1][1].hero);
   }
 
   context.date = new Date(gameData.date);
@@ -500,8 +500,18 @@ function renderToSlot(gameData, slot) {
   let bd = gameData.teams[0];
   let rd = gameData.teams[1];
   for (let i = 0; i < gameData.teams[0].ids.length; i++) {
-    context.blueHeroes.push({heroImg: Heroes.heroIcon(bd.heroes[i]), playerName: bd.names[i], playerID: bd.ids[i], isFocus: focusClass(bd.ids[i]) });
-    context.redHeroes.push({heroImg: Heroes.heroIcon(rd.heroes[i]), playerName: rd.names[i], playerID: rd.ids[i], isFocus: focusClass(rd.ids[i]) });
+    context.blueHeroes.push({
+      heroName: bd.heroes[i],
+      playerName: bd.names[i],
+      playerID: bd.ids[i],
+      isFocus: focusClass(bd.ids[i])
+    });
+    context.redHeroes.push({
+      heroName: rd.heroes[i],
+      playerName: rd.names[i],
+      playerID: rd.ids[i],
+      isFocus: focusClass(rd.ids[i])
+    });
   }
 
   $('#match-list tr[slot="' + slot + '"]').html(matchRowTemplate(context));

--- a/js/matches.js
+++ b/js/matches.js
@@ -31,7 +31,7 @@ function initMatchesPage() {
   });
 
   // templates
-  matchRowTemplate = Handlebars.compile(getTemplate('matches', '#match-summary-row').find('td')[0].outerHTML);
+  matchRowTemplate = getHandlebars('matches', '#match-summary-row');
 
   // bindings
   $('#match-player-search').dropdown();
@@ -246,7 +246,7 @@ function selectMatches() {
     if (heroMode === 'and') {
       if (!('$and' in query))
         query.$and = [];
-      
+
       for (let h in heroes) {
         query.$and.push({ 'heroes' : heroes[h] });
       }
@@ -261,7 +261,7 @@ function selectMatches() {
     if (playerMode === 'and') {
       if (!('$and' in query))
         query.$and = [];
-      
+
       for (let p in players) {
         if (playerWin === 'win') {
           query.$and.push({ 'winningPlayers' : players[p]});
@@ -282,7 +282,7 @@ function selectMatches() {
       else if (playerWin === 'loss') {
         if (!('$or' in query))
           query.$or = [];
-        
+
         for (let p in players) {
           let q = { $and: []};
           q.$and.push({ 'playerIDs' : players[p] });
@@ -317,7 +317,7 @@ function selectMatches() {
         }
       }
       else {
-        // basically we need a match 5 of the players and then we're ok 
+        // basically we need a match 5 of the players and then we're ok
         for (let i = 0; i < 5; i++) {
           const t0key = 'teams.0.ids.' + i;
           const t1key = 'teams.1.ids.' + i;
@@ -387,7 +387,7 @@ function showPage(pageNum) {
 
         // update the pagination buttons
         $('#match-list-page-menu').html('');
-        
+
         // determine what to show
         let show = Array.from(new Array(5), (x, i) => i - 2 + currentPage);
         // first, we always have the first page
@@ -401,16 +401,16 @@ function showPage(pageNum) {
 
         for (let i = 0; i < show.length; i++) {
           let pn = show[i];
-          
+
           if (pn < 1 || pn >= maxPages - 1)
             continue;
-          
+
           elems += '<a class="item" page="' + (pn + 1) + '">' + (pn + 1) + '</a>';
         }
 
         if (show[show.length - 1] < maxPages - 2)
           elems += '<a class="item disabled">...</a>';
-        
+
         if (maxPages > 1) {
           elems += '<a class="item" page="' + maxPages + '">' + maxPages + '</a>';
         }
@@ -456,7 +456,7 @@ function renderToSlot(gameData, slot) {
   context.mapClass = gameData.map.replace(/[^A-Z0-9]/ig, "-");
   context.mode = ReplayTypes.GameModeStrings[gameData.mode];
   context.id = gameData._id;
-  
+
   // if player id is defined, highlight if present, otherwise red/blue
   let focusId = settings.get('selectedPlayerID');
   if ((gameData.teams[0].ids.indexOf(focusId) > -1 && gameData.winner === 0) ||
@@ -478,7 +478,7 @@ function renderToSlot(gameData, slot) {
       context.winText = "Red Team Victory";
     }
   }
-  
+
   if (!gameData.bans) {
     context.hideBans = 'is-hidden';
   }
@@ -557,7 +557,7 @@ function handleMatchesCollectionAction(action, text, $elem) {
   if (action === 'add-current') {
     $('#matches-collection-select .header').text('Add Matches to Collection')
     $('#matches-collection-select p.text').text('All all of the currently selected matches to the spcified collection. Matches can be added to multiple collections.');
-  
+
     $('#matches-collection-select').modal({
       onApprove: function() {
         let collectionID = $('#matches-collection-select .collection-menu').dropdown('get value');
@@ -660,7 +660,7 @@ function handleDeleteMatches(current, remaining) {
 function matchesAddTag(tagValue, tagText, $added) {
   if (!enableTagEdit)
     return;
-  
+
   DB.getMatches(matchSearchQuery, function(err, selectedMatches) {
     let ids = [];
     for (let m of selectedMatches) {

--- a/js/player-ranking.js
+++ b/js/player-ranking.js
@@ -8,16 +8,16 @@ var playerRankingAdditionalTemplate;
 
 function initPlayerRankingPage() {
   // templates
-  playerRankingGeneralTemplate = Handlebars.compile(getTemplate('player-ranking', '#player-ranking-row-template').find('tr')[0].outerHTML);
-  playerRankingTeamfightTemplate = Handlebars.compile(getTemplate('player-ranking', '#player-ranking-teamfight-row-template').find('tr')[0].outerHTML);
-  playerRankingMiscTemplate = Handlebars.compile(getTemplate('player-ranking', '#player-ranking-misc-row-template').find('tr')[0].outerHTML);
-  playerRankingAdditionalTemplate = Handlebars.compile(getTemplate('player-ranking', '#player-ranking-additional-row-template').find('tr')[0].outerHTML);
+  playerRankingGeneralTemplate = getHandlebars('player-ranking', '#player-ranking-row-template');
+  playerRankingTeamfightTemplate = getHandlebars('player-ranking', '#player-ranking-teamfight-row-template');
+  playerRankingMiscTemplate = getHandlebars('player-ranking', '#player-ranking-misc-row-template');
+  playerRankingAdditionalTemplate = getHandlebars('player-ranking', '#player-ranking-additional-row-template');
 
   // filter popup
-  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template').find('.filter-popup-widget')[0].outerHTML);
+  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template'));
   filterWidget.attr('widget-name', 'player-ranking-filter');
   filterWidget.find('.filter-widget-hero').addClass('is-hidden');
-  
+
   $('#filter-widget').append(filterWidget);
   initPopup(filterWidget);
 
@@ -134,7 +134,7 @@ function updateHeroFilter(value, text, $elem) {
 
 function togglePlayerRankingSection() {
   let section = $(this).text();
-  
+
   if ($(this).hasClass('violet')) {
     return;
   }
@@ -191,7 +191,7 @@ function loadPlayerRankings() {
         context.value.totalKDA = player[mode].KDA;
         context.totalKDA = formatStat('KDA', context.value.totalKDA);
       }
-      
+
       context.value.games = player.games;
       context.games = player.games
       context.votes = player.votes;

--- a/js/player.js
+++ b/js/player.js
@@ -16,7 +16,7 @@ const playerHeroDetailRowTemplateContent = `<tr>
   </td>
   </td>
   {{#each stat}}
-    <td class="center aligned" data-sort-value="{{avg}}" data-position="left center" data-variation="wide" data-html='<h4 class="ui image header"><img class="ui rounded image" src="assets/heroes-talents/images/heroes/{{../heroImg}}"><div class="content">{{../heroName}}<div class="ui sub header">{{name}}</div></div></h4>'>
+    <td class="center aligned" data-sort-value="{{avg}}" data-position="left center" data-variation="wide" data-html='<h4 class="ui image header"><img class="ui rounded image" src="{{heroImage ../heroName}}"><div class="content">{{../heroName}}<div class="ui sub header">{{name}}</div></div></h4>'>
       {{render}}
     </td>
   {{/each}}
@@ -624,7 +624,6 @@ function renderAllHeroSummary() {
 
     // some formatting needs to happen
     context.heroName = h;
-    context.heroImg = Heroes.heroIcon(h);
     context.games = playerDetailStats.heroes[h].games;
     context.stats = playerDetailStats.heroes[h].stats;
     context.stats.formatMVPPct = formatStat('pct', context.stats.MVPPct);
@@ -885,7 +884,7 @@ function renderHeroVsStatsTo(container, stats, threshold) {
       context.winPercent = context.wins / context.games;
     }
     context.formatWinPercent = formatStat('pct', context.winPercent);
-    context.heroImg = Heroes.heroIcon(context.name);
+    context.heroName = context.name;
 
     if (context.games >= threshold)
       container.find('tbody').append(heroWinRateRowTemplate(context));
@@ -922,7 +921,6 @@ function renderPlayerHeroDetail() {
     let statData = playerDetailStats[mode][h];
     let context = {};
     context.heroName = h;
-    context.heroImg = Heroes.heroIcon(h);
     context.stat = [];
 
     context.stat.push({

--- a/js/player.js
+++ b/js/player.js
@@ -8,19 +8,6 @@ var playerDetailMapSummaryRowTemplate;
 var allDetailStats;
 var playerAwardRowTemplate;
 var playerCompareRowTemplate;
-const playerHeroDetailRowTemplateContent = `<tr>
-  <td data-sort-value="{{heroName}}">
-    <h3 class="ui inverted header">
-      <div class="content">{{heroName}}</div>
-    </h3>
-  </td>
-  </td>
-  {{#each stat}}
-    <td class="center aligned" data-sort-value="{{avg}}" data-position="left center" data-variation="wide" data-html='<h4 class="ui image header"><img class="ui rounded image" src="{{heroImage ../heroName}}"><div class="content">{{../heroName}}<div class="ui sub header">{{name}}</div></div></h4>'>
-      {{render}}
-    </td>
-  {{/each}}
- </tr>`;
 let playerHeroDetailRowTemplate;
 
 var playerWinRateRowTemplate;
@@ -236,7 +223,7 @@ function initPlayerPage() {
   heroTalentRowTemplate = getHandlebars('player', '#player-detail-talent-row');
   playerAwardRowTemplate = getHandlebars('player', '#player-detail-hero-award-row');
   playerCompareRowTemplate = getHandlebars('player', '#player-compare-table-row');
-  playerHeroDetailRowTemplate = Handlebars.compile(playerHeroDetailRowTemplateContent);
+  playerHeroDetailRowTemplate = getHandlebars('player', '#player-hero-detail-row');
 
   createDetailTableHeader();
 

--- a/js/player.js
+++ b/js/player.js
@@ -6,7 +6,6 @@ var playerDetailInfo;
 var playerDetailHeroSummaryRowTemplate;
 var playerDetailMapSummaryRowTemplate;
 var allDetailStats;
-var playerHeroDetailRowTemplate;
 var playerAwardRowTemplate;
 var playerCompareRowTemplate;
 const playerHeroDetailRowTemplateContent = `<tr>
@@ -22,6 +21,8 @@ const playerHeroDetailRowTemplateContent = `<tr>
     </td>
   {{/each}}
  </tr>`;
+let playerHeroDetailRowTemplate;
+
 var playerWinRateRowTemplate;
 var heroWinRateRowTemplate;
 var heroTalentRowTemplate;
@@ -228,13 +229,13 @@ function initPlayerPage() {
   //$('#players-set-player').dropdown('set selected', selectedPlayerID);
 
   // templates
-  playerDetailHeroSummaryRowTemplate = Handlebars.compile(getTemplate('player', '#player-detail-hero-summary-row').find('tr')[0].outerHTML);
-  playerDetailMapSummaryRowTemplate = Handlebars.compile(getTemplate('player', '#player-detail-map-summary-row').find('tr')[0].outerHTML);
-  playerWinRateRowTemplate = Handlebars.compile(getTemplate('player', '#player-detail-player-win-row').find('tr')[0].outerHTML);
-  heroWinRateRowTemplate = Handlebars.compile(getTemplate('player', '#player-detail-hero-win-row').find('tr')[0].outerHTML);
-  heroTalentRowTemplate = Handlebars.compile(getTemplate('player', '#player-detail-talent-row').find('tr')[0].outerHTML);
-  playerAwardRowTemplate = Handlebars.compile(getTemplate('player', '#player-detail-hero-award-row').find('tr')[0].outerHTML);
-  playerCompareRowTemplate = Handlebars.compile(getTemplate('player', '#player-compare-table-row').find('tr')[0].outerHTML);
+  playerDetailHeroSummaryRowTemplate = getHandlebars('player', '#player-detail-hero-summary-row');
+  playerDetailMapSummaryRowTemplate = getHandlebars('player', '#player-detail-map-summary-row');
+  playerWinRateRowTemplate = getHandlebars('player', '#player-detail-player-win-row');
+  heroWinRateRowTemplate = getHandlebars('player', '#player-detail-hero-win-row');
+  heroTalentRowTemplate = getHandlebars('player', '#player-detail-talent-row');
+  playerAwardRowTemplate = getHandlebars('player', '#player-detail-hero-award-row');
+  playerCompareRowTemplate = getHandlebars('player', '#player-compare-table-row');
   playerHeroDetailRowTemplate = Handlebars.compile(playerHeroDetailRowTemplateContent);
 
   createDetailTableHeader();
@@ -316,7 +317,7 @@ function initPlayerPage() {
   });
 
   // filter popup
-  let playerWidget = $(getTemplate('filter', '#filter-popup-widget-template').find('.filter-popup-widget')[0].outerHTML);
+  let playerWidget = $(getTemplate('filter', '#filter-popup-widget-template'));
   playerWidget.attr('widget-name', 'player-filter');
   playerWidget.find('.filter-widget-team').addClass('is-hidden');
 
@@ -494,7 +495,7 @@ function updatePlayerDetailID(value, text, $item) {
 function updatePlayerPage(err, doc) {
   if (doc.length === 1) {
     playerDetailInfo = doc[0];
-    
+
     updatePlayerPageHeader();
 
     // check player teams

--- a/js/settings.js
+++ b/js/settings.js
@@ -15,9 +15,9 @@ var listedReplays = [];
 
 function initSettingsPage() {
   // templates
-  settingsRowTemplate = Handlebars.compile(getTemplate('settings', '#replay-row-template').find('tr')[0].outerHTML);
-  collectionRowTemplate = Handlebars.compile(getTemplate('settings', '#collection-row-template').find('tr')[0].outerHTML);
-  collectionCacheRowTemplate = Handlebars.compile(getTemplate('settings', '#collection-cache-row-template').find('tr')[0].outerHTML);
+  settingsRowTemplate = getHandlebars('settings', '#replay-row-template');
+  collectionRowTemplate = getHandlebars('settings', '#collection-row-template');
+  collectionCacheRowTemplate = getHandlebars('settings', '#collection-cache-row-template');
 
   let date = settings.get('lastReplayDate');
   if (!date) {

--- a/js/team-ranking.js
+++ b/js/team-ranking.js
@@ -9,13 +9,13 @@ var teamRankingCCTemplate;
 var teamRankingStructureTemplate;
 
 function initTeamRankingPage() {
-  teamRankingGeneralTemplate = Handlebars.compile(getTemplate('team-ranking', '#team-ranking-row-template').find('tr')[0].outerHTML);
-  teamRankingMatchTemplate = Handlebars.compile(getTemplate('team-ranking', '#team-ranking-match-row-template').find('tr')[0].outerHTML);
-  teamRankingCCTemplate = Handlebars.compile(getTemplate('team-ranking', '#team-ranking-cc-row-template').find('tr')[0].outerHTML);
-  teamRankingStructureTemplate = Handlebars.compile(getTemplate('team-ranking', '#team-ranking-structure-row-template').find('tr')[0].outerHTML);
+  teamRankingGeneralTemplate = getHandlebars('team-ranking', '#team-ranking-row-template');
+  teamRankingMatchTemplate = getHandlebars('team-ranking', '#team-ranking-match-row-template');
+  teamRankingCCTemplate = getHandlebars('team-ranking', '#team-ranking-cc-row-template');
+  teamRankingStructureTemplate = getHandlebars('team-ranking', '#team-ranking-structure-row-template');
 
   // filter popup
-  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template').find('.filter-popup-widget')[0].outerHTML);
+  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template'));
   filterWidget.attr('widget-name', 'team-ranking-filter');
   filterWidget.find('.filter-widget-team').addClass('is-hidden');
 
@@ -81,7 +81,7 @@ function resetTeamRankingsFilter() {
 
 function toggleTeamRankingSection() {
   let section = $(this).text();
-  
+
   if ($(this).hasClass('violet')) {
     return;
   }
@@ -123,7 +123,7 @@ function getAllTeamData(filter, callback) {
         }
       }
       else {
-        // basically we need a match 5 of the players and then we're ok 
+        // basically we need a match 5 of the players and then we're ok
         for (let i = 0; i < 5; i++) {
           const t0key = 'teams.0.ids.' + i;
           const t1key = 'teams.1.ids.' + i;

--- a/js/teams.js
+++ b/js/teams.js
@@ -267,7 +267,6 @@ function loadTeamData(team, matches, heroData) {
         games: hero.games,
         winPercent: hero.wins / hero.games,
         pickPercent: hero.games / teamStats.totalMatches,
-        heroImg: Heroes.heroIcon(h),
         heroName: h
       };
       $('#team-hero-summary-table tbody').append(teamHeroSummaryRowTemplate(context));
@@ -283,7 +282,6 @@ function loadTeamData(team, matches, heroData) {
     if (hero.bans > 0 && hero.bans >= teamHeroMatchThresh) {
       const context = {
         heroName: h,
-        heroImg: Heroes.heroIcon(h),
         banPercent: hero.bans / teamStats.totalMatches,
         bans: hero.bans,
         ban1Percent: hero.first / teamStats.totalMatches,
@@ -298,7 +296,6 @@ function loadTeamData(team, matches, heroData) {
     if (hero.games > 0 && hero.games >= teamHeroMatchThresh) {
       const context = {
         heroName: h,
-        heroImg: Heroes.heroIcon(h),
         winPercent: hero.wins / hero.games,
         games: hero.games
       };

--- a/js/teams.js
+++ b/js/teams.js
@@ -22,13 +22,13 @@ function initTeamsPage() {
     fullTextSearch: true
   });
 
-  teamHeroSummaryRowTemplate = Handlebars.compile(getTemplate('teams', '#team-hero-summary-row').find('tr')[0].outerHTML);
-  teamBanSummaryRowTemplate = Handlebars.compile(getTemplate('teams', '#team-hero-ban-row').find('tr')[0].outerHTML);
-  teamRosterRowTemplate = Handlebars.compile(getTemplate('teams', '#team-roster-row').find('tr')[0].outerHTML);
-  teamHeroPickRowTemplate = Handlebars.compile(getTemplate('teams', '#team-hero-pick-row').find('tr')[0].outerHTML);
+  teamHeroSummaryRowTemplate = getHandlebars('teams', '#team-hero-summary-row');
+  teamBanSummaryRowTemplate = getHandlebars('teams', '#team-hero-ban-row');
+  teamRosterRowTemplate = getHandlebars('teams', '#team-roster-row');
+  teamHeroPickRowTemplate = getHandlebars('teams', '#team-hero-pick-row');
 
   // filter popup
-  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template').find('.filter-popup-widget')[0].outerHTML);
+  let filterWidget = $(getTemplate('filter', '#filter-popup-widget-template'));
   filterWidget.attr('widget-name', 'teams-filter');
   filterWidget.find('.filter-widget-team').addClass('is-hidden');
 

--- a/js/util/handlebars.js
+++ b/js/util/handlebars.js
@@ -1,0 +1,21 @@
+const Handlebars = require('handlebars');
+
+// memoize compiled templates for now, ideally it should be preprocessed
+const cache = new Map();
+
+function getTemplate(name, selector) {
+  const link = document.querySelector('link[name="'+ name + '"]');
+  return link.import.querySelector(selector).innerHTML;
+}
+
+function getHandlebars(name, selector) {
+  const key = `${name}-${selector}`;
+  if (cache.has(key)) {
+    return cache.get(`${name}-${selector}`);
+  }
+  const result = Handlebars.compile(getTemplate(name, selector));
+  cache.set(key, result);
+  return result;
+}
+
+module.exports = getHandlebars;

--- a/templates/about-page.html
+++ b/templates/about-page.html
@@ -1,4 +1,4 @@
-<template id="about-page">
+<script id="about-page" type="text/x-handlebars-template">
   <div id="about-page-content" class="is-page transition hidden" section-name="about">
     <div class="ui inverted segment">
       <h1 class="ui inverted header">About</h1>
@@ -150,7 +150,7 @@
           can now be scanned recursively (optional).
         </p>
         <p>
-          Bugfix: <a href="https://github.com/ebshimizu/stats-of-the-storm/issues/145">#145</a> Filter widgets 
+          Bugfix: <a href="https://github.com/ebshimizu/stats-of-the-storm/issues/145">#145</a> Filter widgets
           will now be displayable on more resolutions.
         </p>
         <h3 class="ui inverted dividing header">Version 0.6.0</h3>
@@ -232,7 +232,7 @@
           The fix for this requires an optional re-import to restore this functionality. Player Details and most other sections are unaffected by this bug.
         </p>
         <p>
-          Bugfix: <a href="https://github.com/ebshimizu/stats-of-the-storm/issues/130">#130</a> Parser now properly identifies the same 
+          Bugfix: <a href="https://github.com/ebshimizu/stats-of-the-storm/issues/130">#130</a> Parser now properly identifies the same
           match recorded on different computers.
         </p>
         <h3 class="ui inverted dividing header">Version 0.5.0</h3>
@@ -241,7 +241,7 @@
           and external database comparison support to Stats of the Storm. This version also corrects the match lengths
           in the database. You do not need to re-import your matches to get the extra stats in this version.
           <br>
-          Thanks again to AlexNewell on GitHub for finding some bugs this time around. 
+          Thanks again to AlexNewell on GitHub for finding some bugs this time around.
         </p>
         <p>
           Version 0.5.0 is also the first version of Stats of the Storm available on Mac. This app
@@ -267,7 +267,7 @@
           Match Details: Import path is now shown for each replay.
         </p>
         <p><a href="https://github.com/ebshimizu/stats-of-the-storm/issues/124">#124</a>
-          Parser: Corrected match lengths. Note that the graphs still extend past the match end. This is due 
+          Parser: Corrected match lengths. Note that the graphs still extend past the match end. This is due
           to the last XP breakdown occuring after the game technically ends. For completeness, I have let the graphs
           extend to this duration instead of clamping them.
         </p>
@@ -333,11 +333,11 @@
         <p>Parser update for build 63070.</p>
         <h3 class="ui inverted dividing header">Version 0.3.0</h3>
         <p>
-          Version 0.3.0 fixes a few bugs, adds additional data views for players and teams, lets you parse replays from 
+          Version 0.3.0 fixes a few bugs, adds additional data views for players and teams, lets you parse replays from
           any language, and also allows you to
           compare player and team performance to the overall collection averages. Data for players and matches can
           now be exported in json format from the UI. If you have additional data you'd like to see in those exports,
-          let me know what you'd like to see. 
+          let me know what you'd like to see.
         </p>
         <p><a href="https://github.com/ebshimizu/stats-of-the-storm/issues/85">#85</a>
           Parser: Able to parse replays in all languages.
@@ -400,4 +400,4 @@
       </div>
     </div>
   </div>
-</template>
+</script>

--- a/templates/filter-popup-widget.html
+++ b/templates/filter-popup-widget.html
@@ -1,6 +1,6 @@
 <script src="../js/filter-popup-widget.js"></script>
 
-<template id="filter-popup-widget-template">
+<script id="filter-popup-widget-template" type="text/x-handlebars-template">
   <div class="ui popup filter-popup-widget" data-variation="very wide" widget-name="">
     <div class="ui grid filter-area">
       <div class="three wide column">Mode</div>
@@ -161,4 +161,4 @@
       </div>
     </div>
   </div>
-</template>
+</script>

--- a/templates/hero-collection-page.html
+++ b/templates/hero-collection-page.html
@@ -76,7 +76,7 @@
               <thead>
                 <tr>
                   <th>Hero</th>
-                  <th class="center aligned stat">Games</th> 
+                  <th class="center aligned stat">Games</th>
                   <th class="center aligned stat">Win %</th>
                   <th class="center aligned stat">Bans</th>
                   <th class="center aligned stat">Ban %</th>
@@ -312,7 +312,7 @@
                   </tr>
                 </thead>
                 <tbody>
-  
+
                 </tbody>
               </table>
             </div>
@@ -458,7 +458,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      
+
                     </tbody>
                   </table>
                 </div>
@@ -491,7 +491,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      
+
                     </tbody>
                   </table>
                 </div>
@@ -605,4 +605,17 @@
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
     <td class="center aligned {{deltaClass}}" data-sort-value="{{avgDelta}}">{{formatAvgDelta}}</td>
   </tr>
+</script>
+
+<script id="hero-composition" type="text/x-handlebars-template">
+  <div class="ui five column grid comp-grid">
+  {{#each roles}}
+    <div class="column">
+      <div class="ui mini image">
+        <div class="ui small {{ colorClass }} ribbon label">{{ name }}</div>
+        <img src="assets/images/role_{{ image }}.png">
+      </div>
+    </div>
+  {{/each}}
+  </div>
 </script>

--- a/templates/hero-collection-page.html
+++ b/templates/hero-collection-page.html
@@ -1,7 +1,7 @@
 <script src="../js/hero-collection.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/hero-collection.css">
 
-<template id="hero-collection-page">
+<script id="hero-collection-page" type="text/x-handlebars-template">
   <div id="hero-collection-page-content" class="is-page transition hidden" section-name="hero-collection">
     <div id="hero-collection-page-header">
       <div class="ui grid">
@@ -539,9 +539,9 @@
       <div class="ui red deny button">Cancel</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="hero-collection-hero-summary-row-template">
+<script id="hero-collection-hero-summary-row-template" type="text/x-handlebars-template">
   <tr class="hero-collection-hero-summary-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
@@ -559,9 +559,9 @@
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
     <td class="center aligned" data-sort-value="{{bans}}">{{bans}}</td>
   </tr>
-</template>
+</script>
 
-<template id="hero-collection-hero-pick-row-template">
+<script id="hero-collection-hero-pick-row-template" type="text/x-handlebars-template">
   <tr class="hero-collection-hero-summary-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
@@ -589,9 +589,9 @@
     <td class="center aligned" data-sort-value="{{picks.round3.pct}}">{{picks.round3.formatPct}}</td>
     <td class="center aligned" data-sort-value="{{picks.round3.wins}}">{{picks.round3.wins}}</td>
   </tr>
-</template>
+</script>
 
-<template id="hero-collection-detail-hero-win-row">
+<script id="hero-collection-detail-hero-win-row" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}">
       <h3 class="ui image inverted header">
@@ -605,4 +605,4 @@
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
     <td class="center aligned {{deltaClass}}" data-sort-value="{{avgDelta}}">{{formatAvgDelta}}</td>
   </tr>
-</template>
+</script>

--- a/templates/hero-collection-page.html
+++ b/templates/hero-collection-page.html
@@ -545,7 +545,7 @@
   <tr class="hero-collection-hero-summary-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>
@@ -565,7 +565,7 @@
   <tr class="hero-collection-hero-summary-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>
@@ -595,7 +595,7 @@
   <tr>
     <td data-sort-value="{{name}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{name}}
         </div>

--- a/templates/maps-page.html
+++ b/templates/maps-page.html
@@ -1,7 +1,7 @@
 <script src="../js/maps.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/maps.css">
 
-<template id="maps-page">
+<script id="maps-page" type="text/x-handlebars-template">
   <div id="maps-page-content" class="is-page transition hidden" section-name="maps">
     <div id="maps-page-header">
       <div class="ui grid">
@@ -82,9 +82,9 @@
       </div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="map-table-row-template">
+<script id="map-table-row-template" type="text/x-handlebars-template">
   <tr class="map-table-row">
     <td><h3 class="ui inverted header">{{map}}</h3></td>
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
@@ -97,4 +97,4 @@
     <td class="center aligned" data-sort-value="{{blueWinPct}}">{{formatPct blueWinPct}}</td>
     <td class="center aligned" data-sort-value="{{redWinPct}}">{{formatPct redWinPct}}</td>
   </tr>
-</template>
+</script>

--- a/templates/match-detail-page.html
+++ b/templates/match-detail-page.html
@@ -194,11 +194,11 @@
                 <div class="statistic" name="team-time-to-10">
                   <div class="value">###</div>
                   <div class="label">Time To 10</div>
-                </div> 
+                </div>
                 <div class="statistic" name="team-time-to-20">
                   <div class="value">###</div>
                   <div class="label">Time To 20</div>
-                </div> 
+                </div>
               </div>
               <div class="ui inverted horizontal divider">Mercenaries</div>
               <div class="ui three inverted blue statistics">
@@ -303,11 +303,11 @@
                 <div class="statistic" name="team-time-to-10">
                   <div class="value">###</div>
                   <div class="label">Time To 10</div>
-                </div> 
+                </div>
                 <div class="statistic" name="team-time-to-20">
                   <div class="value">###</div>
                   <div class="label">Time To 20</div>
-                </div> 
+                </div>
               </div>
               <div class="ui inverted horizontal divider">Mercenaries</div>
               <div class="ui three inverted red statistics">
@@ -594,7 +594,7 @@
   <tr class="match-detail-summary-row {{teamColor}}" playerID="{{playerID}}">
     <td data-sort-value="{{teamColor}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui large rounded image">
+        <img src="{{heroImage heroName}}" class="ui large rounded image">
         <div class="content">
           {{heroName}}
           <div class="sub header player-name" playerID="{{playerID}}">{{playerName}}</div>
@@ -618,7 +618,7 @@
 <script id="match-detail-detail-header" type="text/x-handlebars-template">
   <th class="{{teamColor}}">
     <h4 class="ui image inverted header">
-      <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui tiny rounded image">
+      <img src="{{heroImage heroName}}" class="ui tiny rounded image">
       <div class="content">
         {{heroName}}
         <div class="sub header player-name" playerID="{{playerID}}">{{playerName}}</div>
@@ -631,7 +631,7 @@
   <tr class="match-detail-talents-row {{teamColor}}" playerID="{{playerID}}">
     <td>
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui large rounded image">
+        <img src="{{heroImage heroName}}" class="ui large rounded image">
         <div class="content">
           {{heroName}}
           <div class="sub header player-name" playerID="{{playerID}}">{{playerName}}</div>
@@ -653,7 +653,7 @@
 <script id="match-detail-chat-log-entry" type="text/x-handlebars-template">
   <div class="event">
     <div class="label {{showImg}}">
-      <img src="assets/heroes-talents/images/heroes/{{heroImg}}">
+      <img src="{{heroImage heroName}}">
     </div>
     <div class="content">
       <div class="date">{{time}}</div>
@@ -661,7 +661,7 @@
         {{playerName}}: {{message}}
       </div>
     </div>
-  </div> 
+  </div>
 </script>
 
 <script id="match-detail-taunt-entry" type="text/x-handlebars-template">

--- a/templates/match-detail-page.html
+++ b/templates/match-detail-page.html
@@ -2,7 +2,7 @@
 <script src="../js/match-detail.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/match-detail.css">
 
-<template id="match-detail-page">
+<script id="match-detail-page" type="text/x-handlebars-template">
   <div id="match-detail-page-content" class="is-page transition hidden" section-name="match-detail">
     <div id="match-detail-page-header">
       <div class="ui grid">
@@ -588,9 +588,9 @@
       <div class="ui red deny button">Cancel</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="match-detail-summary-row-template">
+<script id="match-detail-summary-row-template" type="text/x-handlebars-template">
   <tr class="match-detail-summary-row {{teamColor}}" playerID="{{playerID}}">
     <td data-sort-value="{{teamColor}}">
       <h3 class="ui image inverted header">
@@ -613,9 +613,9 @@
     <td class="center aligned" data-sort-value="{{gameStats.DamageTaken}}"><div class="ui inverted mini statistic"><div class="value">{{format.DamageTaken}}</div></div></td>
     <td class="center aligned" data-sort-value="{{gameStats.ExperienceContribution}}"><div class="ui inverted mini statistic"><div class="value">{{format.ExperienceContribution}}</div></div></td>
   </tr>
-</template>
+</script>
 
-<template id="match-detail-detail-header">
+<script id="match-detail-detail-header" type="text/x-handlebars-template">
   <th class="{{teamColor}}">
     <h4 class="ui image inverted header">
       <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui tiny rounded image">
@@ -625,9 +625,9 @@
       </div>
     </h4>
   </th>
-</template>
+</script>
 
-<template id="match-detail-talents-row-title-template">
+<script id="match-detail-talents-row-title-template" type="text/x-handlebars-template">
   <tr class="match-detail-talents-row {{teamColor}}" playerID="{{playerID}}">
     <td>
       <h3 class="ui image inverted header">
@@ -639,18 +639,18 @@
       </h3>
     </td>
   </tr>
-</template>
+</script>
 
-<template id="match-detail-talents-row-cell-template">
+<script id="match-detail-talents-row-cell-template" type="text/x-handlebars-template">
   <td data-sort-value="{{name}}">
     <div class="ui content">
       <img src="assets/heroes-talents/images/talents/{{img}}" class="ui centered tiny rounded image"
         data-html='<div class="header">{{name}}</div><div class="content">{{description}}</div>' data-position="left center">
     </div>
   </td>
-</template>
+</script>
 
-<template id="match-detail-chat-log-entry">
+<script id="match-detail-chat-log-entry" type="text/x-handlebars-template">
   <div class="event">
     <div class="label {{showImg}}">
       <img src="assets/heroes-talents/images/heroes/{{heroImg}}">
@@ -662,9 +662,9 @@
       </div>
     </div>
   </div> 
-</template>
+</script>
 
-<template id="match-detail-taunt-entry">
+<script id="match-detail-taunt-entry" type="text/x-handlebars-template">
   <tr>
     <td>{{name}}</td>
     <td>{{type}}</td>
@@ -672,4 +672,4 @@
     <td>{{kills}}</td>
     <td>{{deaths}}</td>
   </tr>
-</template>
+</script>

--- a/templates/matches-page.html
+++ b/templates/matches-page.html
@@ -10,7 +10,7 @@
           <h1 class="ui inverted header">Matches</h1>
         </div>
         <div class="eight wide column">
-          
+
         </div>
       </div>
     </div>
@@ -176,7 +176,7 @@
                 <i class="dropdown icon"></i>
                 <span class="default text">All Players</span>
                 <div class="menu">
-    
+
                 </div>
               </div>
             </div>
@@ -207,7 +207,7 @@
                 <i class="dropdown icon"></i>
                 <span class="default text">Team</span>
                 <div class="menu">
-    
+
                 </div>
               </div>
               <div class="ui right floated icon button" id="match-search-clear-team">
@@ -289,17 +289,17 @@
           <div class="ui inverted blue horizontal divider {{hideBans}}">Blue Bans</div>
           <div class="ui two column grid {{hideBans}}">
             <div class="column">
-              <img class="ui circular blue-hero middle-align image" src="assets/heroes-talents/images/heroes/{{bban1Img}}">
+              <img class="ui circular blue-hero middle-align image" src="{{heroImage bban1Hero}}">
             </div>
             <div class="column">
-              <img class="ui circular blue-hero middle-align image" src="assets/heroes-talents/images/heroes/{{bban2Img}}">
+              <img class="ui circular blue-hero middle-align image" src="{{heroImage bban2Hero}}">
             </div>
           </div>
           <div class="blue-team-nameplate"></div>
         </div>
         {{#each blueHeroes}}
         <div class="ui column">
-          <img class="ui circular blue-hero middle-align image {{isFocus}}" src="assets/heroes-talents/images/heroes/{{heroImg}}" data-content="{{playerName}}" player-id="{{playerID}}" data-position="top center">
+          <img class="ui circular blue-hero middle-align image {{isFocus}}" src="{{heroImage heroName}}" data-content="{{playerName}}" player-id="{{playerID}}" data-position="top center">
         </div>
         {{/each}}
         <div class="ui two wide column match-center-stats">
@@ -323,17 +323,17 @@
         </div>
         {{#each redHeroes}}
         <div class="ui column">
-          <img class="ui circular red-hero middle-align image {{isFocus}}" src="assets/heroes-talents/images/heroes/{{heroImg}}" data-content="{{playerName}}" player-id="{{playerID}}" data-position="top center">
+          <img class="ui circular red-hero middle-align image {{isFocus}}" src="{{heroImage heroName}}" data-content="{{playerName}}" player-id="{{playerID}}" data-position="top center">
         </div>
         {{/each}}
         <div class="ui two wide column red-bans">
           <div class="ui inverted red horizontal divider {{hideBans}}">Red Bans</div>
           <div class="ui two column grid {{hideBans}}">
             <div class="column">
-              <img class="ui circular red-hero middle-align image" src="assets/heroes-talents/images/heroes/{{rban1Img}}">
+              <img class="ui circular red-hero middle-align image" src="{{heroImage rban1Hero}}">
             </div>
             <div class="column">
-              <img class="ui circular red-hero middle-align image" src="assets/heroes-talents/images/heroes/{{rban2Img}}">
+              <img class="ui circular red-hero middle-align image" src="{{heroImage rban2Hero}}">
             </div>
           </div>
           <div class="red-team-nameplate"></div>

--- a/templates/matches-page.html
+++ b/templates/matches-page.html
@@ -2,7 +2,7 @@
 <script src="../js/matches.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/matches.css">
 
-<template id="matches-page">
+<script id="matches-page" type="text/x-handlebars-template">
   <div id="matches-page-content" class="is-page transition hidden" section-name="matches">
     <div id="matches-page-header">
       <div class="ui grid">
@@ -266,9 +266,9 @@
       <div class="ui red deny button">No</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="match-summary-row">
+<script id="match-summary-row" type="text/x-handlebars-template">
   <td class="{{mapClass}}">
     <div class="bg-dimmer"></div>
     <div class="match-summary {{mapClass}}" match-id="{{id}}">
@@ -342,4 +342,4 @@
       <div class="clear"></div>
     </div>
   </td>
-</template>
+</script>

--- a/templates/player-page.html
+++ b/templates/player-page.html
@@ -1,7 +1,7 @@
 <script src="../js/player.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/player.css">
 
-<template id="player-page">
+<script id="player-page" type="text/x-handlebars-template">
   <div id="player-page-content" class="is-page transition hidden" section-name="player">
     <div id="player-page-header">
       <div class="ui grid">
@@ -721,9 +721,9 @@
       <div class="ui red deny button">Cancel</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="player-detail-hero-summary-row">
+<script id="player-detail-hero-summary-row" type="text/x-handlebars-template">
   <tr class="player-detail-summary-row">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
@@ -743,9 +743,9 @@
     <td class="center aligned" data-sort-value="{{stats.MVPPct}}">{{stats.formatMVPPct}}</td>
     <td class="center aligned" data-sort-value="{{stats.AwardPct}}">{{stats.formatAwardPct}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-detail-map-summary-row">
+<script id="player-detail-map-summary-row" type="text/x-handlebars-template">
   <tr class="player-detail-map-summary-row">
     <td>
       <h4 class="ui inverted header">{{mapName}}</h3>
@@ -753,9 +753,9 @@
     <td class="center aligned" data-sort-value="{{winPct}}">{{formatWinPct}}</td>
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-detail-player-win-row">
+<script id="player-detail-player-win-row" type="text/x-handlebars-template">
   <tr>
     <td>
       <h4 class="ui inverted header">{{name}}</h4>
@@ -763,9 +763,9 @@
     <td class="center aligned" data-sort-value="{{winPercent}}">{{formatWinPercent}}</td>
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-detail-hero-win-row">
+<script id="player-detail-hero-win-row" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}">
       <h3 class="ui image inverted header">
@@ -778,9 +778,9 @@
     <td class="center aligned" data-sort-value="{{winPercent}}">{{formatWinPercent}}</td>
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-detail-talent-row">
+<script id="player-detail-talent-row" type="text/x-handlebars-template">
   <tr>
     <td>
       <div class="ui items">
@@ -801,9 +801,9 @@
     <td class="center aligned talent-stat">{{formatPop}}</td>
     <td class="center aligned talent-stat">{{games}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-detail-hero-award-row">
+<script id="player-detail-hero-award-row" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}">
       <h3 class="ui image inverted header">
@@ -817,13 +817,13 @@
     <td class="center aligned" data-sort-value="{{winPercent}}">{{formatWinPercent}}</td>
     <td class="center aligned" data-sort-value="{{games}}">{{games}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-compare-table-row">
+<script id="player-compare-table-row" type="text/x-handlebars-template">
   <tr>
     <td><h3 class="ui inverted header">{{statName}}</h3></td>
     <td class="center aligned" data-sort-value="{{pDataSort}}">{{pData}}</td>
     <td class="center aligned" data-sort-value="{{pctDiff}}">{{pctDiffFormat}}</td>
     <td class="center aligned" data-sort-value="{{cmpDataSort}}">{{cmpData}}</td>
   </tr>
-</template>
+</script>

--- a/templates/player-page.html
+++ b/templates/player-page.html
@@ -1,6 +1,22 @@
 <script src="../js/player.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/player.css">
 
+<script id="player-hero-detail-row"  type="text/x-handlebars-template">
+  <tr>
+    <td data-sort-value="{{heroName}}">
+      <h3 class="ui inverted header">
+        <div class="content">{{heroName}}</div>
+      </h3>
+    </td>
+    </td>
+    {{#each stat}}
+    <td class="center aligned" data-sort-value="{{avg}}" data-position="left center" data-variation="wide" data-html='<h4 class="ui image header"><img class="ui rounded image" src="{{heroImage ../heroName}}"><div class="content">{{../heroName}}<div class="ui sub header">{{name}}</div></div></h4>'>
+      {{render}}
+    </td>
+    {{/each}}
+  </tr>
+</script>
+
 <script id="player-page" type="text/x-handlebars-template">
   <div id="player-page-content" class="is-page transition hidden" section-name="player">
     <div id="player-page-header">

--- a/templates/player-page.html
+++ b/templates/player-page.html
@@ -81,7 +81,7 @@
                         </tr>
                       </thead>
                       <tbody>
-                        
+
                       </tbody>
                     </table>
                   </div>
@@ -352,7 +352,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      
+
                     </tbody>
                   </table>
                 </div>
@@ -371,7 +371,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      
+
                     </tbody>
                   </table>
                 </div>
@@ -422,7 +422,7 @@
                       </tr>
                     </thead>
                     <tbody>
-                      
+
                     </tbody>
                   </table>
                 </div>
@@ -541,7 +541,7 @@
                     <div class="label">Deaths</div>
                   </div>
                 </div>
-                <div class="ui inverted divider"></div> 
+                <div class="ui inverted divider"></div>
               </div>
             </div>
             <div class="five wide column">
@@ -727,7 +727,7 @@
   <tr class="player-detail-summary-row">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>
@@ -769,7 +769,7 @@
   <tr>
     <td data-sort-value="{{name}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{name}}
         </div>

--- a/templates/player-ranking-page.html
+++ b/templates/player-ranking-page.html
@@ -1,7 +1,7 @@
 <script src="../js/player-ranking.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/player-ranking.css">
 
-<template id="player-ranking-page">
+<script id="player-ranking-page" type="text/x-handlebars-template">
   <div id="player-ranking-page-content" class="is-page transition hidden" section-name="player-ranking">
     <div id="player-ranking-page-header">
       <div class="ui grid">
@@ -206,9 +206,9 @@
       <div class="ui red deny button">Cancel</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="player-ranking-row-template">
+<script id="player-ranking-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header player-name" playerID="{{id}}">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{value.winPercent}}">{{formatWinPercent}}</td>
@@ -231,9 +231,9 @@
     <td class="center aligned" data-sort-value="{{value.SelfHealing}}">{{SelfHealing}}</td>
     <td class="center aligned" data-sort-value="{{value.ProtectionGivenToAllies}}">{{ProtectionGivenToAllies}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-ranking-additional-row-template">
+<script id="player-ranking-additional-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header player-name" playerID="{{id}}">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{value.winPercent}}">{{formatWinPercent}}</td>
@@ -254,10 +254,10 @@
     <td class="center aligned" data-sort-value="{{value.healingDonePerDeath}}">{{healingDonePerDeath}}</td>
     <td class="center aligned" data-sort-value="{{value.HPM}}">{{HPM}}</td>
   </tr>
-</template>
+</script>
 
 
-<template id="player-ranking-teamfight-row-template">
+<script id="player-ranking-teamfight-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header player-name" playerID="{{id}}">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{value.winPercent}}">{{formatWinPercent}}</td>
@@ -275,9 +275,9 @@
     <td class="center aligned" data-sort-value="{{value.TimeSilencingEnemyHeroes}}">{{TimeSilencingEnemyHeroes}}</td>
     <td class="center aligned" data-sort-value="{{value.VengeancesPerformed}}">{{VengeancesPerformed}}</td>
   </tr>
-</template>
+</script>
 
-<template id="player-ranking-misc-row-template">
+<script id="player-ranking-misc-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header player-name" playerID="{{id}}">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{value.winPercent}}">{{formatWinPercent}}</td>
@@ -301,4 +301,4 @@
     <td class="center aligned" data-sort-value="{{taunts.dances.takedowns}}">{{taunts.dances.takedowns}}</td>
     <td class="center aligned" data-sort-value="{{taunts.dances.deaths}}">{{taunts.dances.deaths}}</td>
   </tr>
-</template>
+</script>

--- a/templates/settings-page.html
+++ b/templates/settings-page.html
@@ -1,7 +1,7 @@
 <script src="../js/settings.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/settings.css">
 
-<template id="settings-page">
+<script id="settings-page" type="text/x-handlebars-template">
     <div id="settings-page-content" class="is-page transition hidden" section-name="settings">
         <div class="ui grid" id="settings-layout">
             <div class="eleven wide column">
@@ -311,9 +311,9 @@
             </div>
         </div>
     </div>
-</template>
+</script>
 
-<template id="replay-row-template">
+<script id="replay-row-template" type="text/x-handlebars-template">
     <tr replay-id="{{id}}">
         <td class="replay-filename">{{filename}}</td>
         <td class="replay-folder">{{folder}}</td>
@@ -321,9 +321,9 @@
         <td class="replay-status">{{status}}</td>
         <td class="upload-status">{{upload}}</td>
     </tr>
-</template>
+</script>
 
-<template id="collection-row-template">
+<script id="collection-row-template" type="text/x-handlebars-template">
     <tr>
         <td>{{name}}</td>
         <td>
@@ -331,9 +331,9 @@
             <div class="ui red button" collection-id="{{_id}}" collection-name="{{name}}" action="delete">Delete</div>
         </td>
     </tr>
-</template>
+</script>
 
-<template id="collection-cache-row-template">
+<script id="collection-cache-row-template" type="text/x-handlebars-template">
     <tr>
         <td collection-name="{{name}}">{{name}}</td>
         <td>{{count}}</td>
@@ -342,4 +342,4 @@
             <div class="ui red button" collection-id="{{_id}}" collection-name="{{name}}" action="delete">Delete</div>
         </td>
     </tr>
-</template>
+</script>

--- a/templates/team-ranking-page.html
+++ b/templates/team-ranking-page.html
@@ -1,7 +1,7 @@
 <script src="../js/team-ranking.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/team-ranking.css">
 
-<template id="team-ranking-page">
+<script id="team-ranking-page" type="text/x-handlebars-template">
   <div id="team-ranking-page-content" class="is-page transition hidden" section-name="team-ranking">
     <div id="team-ranking-page-header">
       <div class="ui grid">
@@ -169,9 +169,9 @@
       <div class="ui red deny button">Cancel</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="team-ranking-row-template">
+<script id="team-ranking-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{winPercent}}">{{formatWinPercent}}</td>
@@ -192,9 +192,9 @@
     <td class="center aligned" data-sort-value="{{stats.average.SelfHealing}}">{{SelfHealing}}</td>
     <td class="center aligned" data-sort-value="{{stats.average.ProtectionGivenToAllies}}">{{ProtectionGivenToAllies}}</td>
   </tr>
-</template>
+</script>
 
-<template id="team-ranking-match-row-template">
+<script id="team-ranking-match-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{winPercent}}">{{formatWinPercent}}</td>
@@ -214,9 +214,9 @@
     <td class="center aligned" data-sort-value="{{stats.average.mercUptime}}">{{mercUptime}}</td>
     <td class="center aligned" data-sort-value="{{stats.average.mercUptimePercent}}">{{mercUptimePercent}}</td>
   </tr>
-</template>
+</script>
 
-<template id="team-ranking-cc-row-template">
+<script id="team-ranking-cc-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{winPercent}}">{{formatWinPercent}}</td>
@@ -229,9 +229,9 @@
     <td class="center aligned" data-sort-value="{{stats.average.TimeSilencingEnemyHeroes}}">{{TimeSilencingEnemyHeroes}}</td>
     <td class="center aligned" data-sort-value="{{stats.average.TimeStunningEnemyHeroes}}">{{TimeStunningEnemyHeroes}}</td>
   </tr>
-</template>
+</script>
 
-<template id="team-ranking-structure-row-template">
+<script id="team-ranking-structure-row-template" type="text/x-handlebars-template">
   <tr>
     <td data-sort-value="{{name}}"><h3 class="ui inverted header">{{name}}</h3></td>
     <td class="center aligned" data-sort-value="{{winPercent}}">{{formatWinPercent}}</td>
@@ -243,4 +243,4 @@
     <td class="center aligned" data-sort-value="{{structures.Keep.first}}">{{structures.Keep.formatFirst}}</td>
     <td class="center aligned" data-sort-value="{{structures.Keep.lost}}">{{structures.Keep.lost}}</td>
   </tr>
-</template>
+</script>

--- a/templates/teams-page.html
+++ b/templates/teams-page.html
@@ -2,7 +2,7 @@
 <script src="../js/teams.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/teams.css">
 
-<template id="teams-page">
+<script id="teams-page" type="text/x-handlebars-template">
   <div id="teams-page-content" class="is-page transition hidden" section-name="teams">
     <div id="teams-page-header">
       <div class="ui grid">
@@ -564,9 +564,9 @@
       <div class="ui red deny button">Cancel</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="team-hero-summary-row">
+<script id="team-hero-summary-row" type="text/x-handlebars-template">
   <tr>
     <td>
       <h3 class="ui image inverted header">
@@ -585,9 +585,9 @@
     <td class="center aligned" data-sort-value="{{TimeSpentDead}}">{{formatSeconds TimeSpentDead}}</td>
     <td class="center aligned" data-sort-value="{{timeDeadPct}}">{{formatPct timeDeadPct}}</td>
   </tr>
-</template>
+</script>
 
-<template id="team-hero-pick-row">
+<script id="team-hero-pick-row" type="text/x-handlebars-template">
   <tr>
     <td>
       <h3 class="ui image inverted header">
@@ -603,9 +603,9 @@
     <td class="center aligned" data-sort-value="{{round2Percent}}">{{formatPct round2Percent}}</td>
     <td class="center aligned" data-sort-value="{{round3Percent}}">{{formatPct round3Percent}}</td>
   </tr>
-</template>
+</script>
 
-<template id="team-hero-ban-row">
+<script id="team-hero-ban-row" type="text/x-handlebars-template">
   <tr>
     <td>
       <h3 class="ui image inverted header">
@@ -622,9 +622,9 @@
     <td class="center aligned" data-sort-value="{{ban2Percent}}">{{formatPct ban2Percent}}</td>
     <td class="center aligned" data-sort-value="{{ban2}}">{{ban2}}</td>
   </tr>
-</template>
+</script>
 
-<template id="team-roster-row">
+<script id="team-roster-row" type="text/x-handlebars-template">
   <tr>
     <td><h3 class="ui inverted header player-name" playerID="{{id}}">{{name}}</h3></td>
     <td class="center aligned top-three" player-id="{{id}}">
@@ -656,4 +656,4 @@
       </div>
     </td>
   </tr>
-</template>
+</script>

--- a/templates/teams-page.html
+++ b/templates/teams-page.html
@@ -570,7 +570,7 @@
   <tr>
     <td>
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>
@@ -591,7 +591,7 @@
   <tr>
     <td>
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>
@@ -609,7 +609,7 @@
   <tr>
     <td>
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>

--- a/templates/trends-page.html
+++ b/templates/trends-page.html
@@ -1,7 +1,7 @@
 <script src="../js/hero-trends.js"></script>
 <link rel="stylesheet" type="text/css" href="../assets/css/hero-trends.css">
 
-<template id="hero-trends-page">
+<script id="hero-trends-page" type="text/x-handlebars-template">
   <div id="hero-trends-page-content" class="is-page transition hidden" section-name="hero-trends">
     <div id="hero-trends-page-header">
       <div class="ui grid">
@@ -208,9 +208,10 @@
       <div class="ui red deny button">Cancel</div>
     </div>
   </div>
-</template>
+</script>
 
-<template id="trends-hero-summary-row-template">
+<script id="trends-hero-summary-row-template" type="text/x-handlebars-template">
+  {{#each context}}
   <tr class="trends-hero-summary-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
@@ -233,9 +234,11 @@
     <td class="center aligned" data-sort-value="{{period2.win.games}}">{{period2.win.games}}</td>
     <td class="center aligned {{statSign.games}}" data-sort-value="{{delta.games}}">{{deltaFmt.games}}</td>
   </tr>
-</template>
+  {{/each}}
+</script>
 
-<template id="trends-hero-pick-row-template">
+<script id="trends-hero-pick-row-template" type="text/x-handlebars-template">
+  {{#each context}}
   <tr class="trends-hero-pick-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
@@ -258,9 +261,11 @@
     <td class="center aligned" data-sort-value="{{period2.draft.picks.round3.pct}}">{{formatPct period2.draft.picks.round3.pct}}</td>
     <td class="center aligned {{statSign.r3}}" data-sort-value="{{delta.r3}}">{{deltaFmt.r3}}</td>
   </tr>
-</template>
+  {{/each}}
+</script>
 
-<template id="trends-hero-pick-ban-template">
+<script id="trends-hero-pick-ban-template" type="text/x-handlebars-template">
+  {{#each context}}
   <tr class="trends-hero-ban-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
@@ -280,4 +285,5 @@
     <td class="center aligned" data-sort-value="{{period2.draft.secondBanPercent}}">{{formatPct period2.draft.secondBanPercent}}</td>
     <td class="center aligned {{statSign.secondBanPercent}}" data-sort-value="{{delta.secondBanPercent}}">{{deltaFmt.secondBanPercent}}</td>
   </tr>
-</template>
+  {{/each}}
+</script>

--- a/templates/trends-page.html
+++ b/templates/trends-page.html
@@ -215,7 +215,7 @@
   <tr class="trends-hero-summary-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>
@@ -242,7 +242,7 @@
   <tr class="trends-hero-pick-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>
@@ -269,7 +269,7 @@
   <tr class="trends-hero-ban-row {{heroRole}}">
     <td data-sort-value="{{heroName}}">
       <h3 class="ui image inverted header">
-        <img src="assets/heroes-talents/images/heroes/{{heroImg}}" class="ui rounded image">
+        <img src="{{heroImage heroName}}" class="ui rounded image">
         <div class="content">
           {{heroName}}
         </div>


### PR DESCRIPTION
Hi!,

* Cache compiled handlebars templates
* Changed handlebar markup from `<template>` to `<script>` to speed up loading times. This prevents the browser window from parsing the markup and creating unnecessary DOM elements as we'll end up getting the HTML string anyway. Also this allows the templates to include handlebars markup at outermost scope 
* `heroImage` handlebars helper

I kept the `getTemplate` function as is and added a `getHandlebars` method.

Ideally you'd want the following setup:
* Split templates into separate files
* Add some sort of watch to precompile HBS templates during development and before packing the app
* Use those objects in the app instead of raw HBS strings