### PR TITLE
reuse tags and version info during startup

### DIFF
--- a/js/filter-popup-widget.js
+++ b/js/filter-popup-widget.js
@@ -1,6 +1,6 @@
 var popupWidgetResetCallback = null;
 
-function initPopup(elem) {
+function initPopup(elem, tags) {
   // modes
   elem.find('.filter-widget-mode').dropdown({
     action: 'activate',
@@ -79,7 +79,7 @@ function initPopup(elem) {
     fullTextSearch: true
   });
 
-  populateTagMenu(elem.find('.filter-widget-tags'));
+  populateTagMenuWithValues(elem.find('.filter-widget-tags'), tags);
 
   // the buttons get rebound depending on the page
   elem.find('.filter-widget-reset').click(function() { resetFilterWidget(elem) });

--- a/js/hero-collection.js
+++ b/js/hero-collection.js
@@ -16,7 +16,7 @@ var heroCollectionTables = {
   players: null
 }
 
-function initHeroCollectionPage() {
+function initHeroCollectionPage(tags) {
   // by default this screen containrs games played in official modes with bans
   heroCollectionHeroDataFilter = {
     mode: { $in: [ReplayTypes.GameMode.UnrankedDraft, ReplayTypes.GameMode.HeroLeague, ReplayTypes.GameMode.TeamLeague, ReplayTypes.GameMode.Custom]}
@@ -66,7 +66,7 @@ function initHeroCollectionPage() {
   filterWidget.attr('widget-name', 'hero-collection-filter');
 
   $('#filter-widget').append(filterWidget);
-  initPopup(filterWidget);
+  initPopup(filterWidget, tags);
 
   $('#hero-collection-filter-button').popup({
     popup: '.filter-popup-widget[widget-name="hero-collection-filter"]',

--- a/js/hero-trends.js
+++ b/js/hero-trends.js
@@ -11,7 +11,7 @@ var trendsDateLimits = {
   '2-end': new Date()
 };
 
-function initTrendsPage() {
+function initTrendsPage(tags) {
   trendsHeroDataFilter = {
     mode: { $in: [ReplayTypes.GameMode.UnrankedDraft, ReplayTypes.GameMode.HeroLeague, ReplayTypes.GameMode.TeamLeague, ReplayTypes.GameMode.Custom]}
   }
@@ -38,7 +38,7 @@ function initTrendsPage() {
   filterWidget.attr('widget-name', 'hero-trends-filter');
 
   $('#filter-widget').append(filterWidget);
-  initPopup(filterWidget);
+  initPopup(filterWidget, tags);
 
   $('#hero-trends-filter-button').popup({
     popup: '.filter-popup-widget[widget-name="hero-trends-filter"]',

--- a/js/index.js
+++ b/js/index.js
@@ -101,7 +101,6 @@ $.fn.datepicker.setDefaults({
 
 var DB;
 var dbVersions;
-var dbTags;
 var sections = {};
 var prevSections = [];
 
@@ -174,10 +173,9 @@ function resumeInitApp() {
     dbVersions = versions;
     setLoadMessage('Retrieving tags');
     DB.getTags(function(tags) {
-      dbTags = tags;
       // sections
       setLoadMessage('Loading Sections');
-      loadSections();
+      loadSections(tags);
       $('.app-version-number').text(app.getVersion());
 
       // populate some menus
@@ -270,39 +268,39 @@ function initGlobalUIHandlers() {
   });
 }
 
-function loadSections() {
+function loadSections(tags) {
   // settings
   $('#main-content').append(getTemplate('settings', '#settings-page'));
   initSettingsPage();
 
   $('#main-content').append(getTemplate('matches', '#matches-page'));
-  initMatchesPage();
+  initMatchesPage(tags);
 
   $('#main-content').append(getTemplate('match-detail', '#match-detail-page'));
   initMatchDetailPage();
 
   $('#main-content').append(getTemplate('player', '#player-page'));
-  initPlayerPage();
+  initPlayerPage(tags);
 
   $('#main-content').append(getTemplate('hero-collection', '#hero-collection-page'));
-  initHeroCollectionPage();
+  initHeroCollectionPage(tags);
 
   $('#main-content').append(getTemplate('player-ranking', '#player-ranking-page'));
-  initPlayerRankingPage();
+  initPlayerRankingPage(tags);
 
   $('#main-content').append(getTemplate('teams', '#teams-page'));
-  initTeamsPage();
+  initTeamsPage(tags);
 
   $('#main-content').append(getTemplate('team-ranking', '#team-ranking-page'))
-  initTeamRankingPage();
+  initTeamRankingPage(tags);
 
   $('#main-content').append(getTemplate('about', '#about-page'));
 
   $('#main-content').append(getTemplate('trends', '#hero-trends-page'));
-  initTrendsPage();
+  initTrendsPage(tags);
 
   $('#main-content').append(getTemplate('maps', '#maps-page'));
-  initMapsPage();
+  initMapsPage(tags);
 
   // register sections
   sections.settings = {id: '#settings-page-content', title: 'App Settings', showBack: false, onShow: showSettingsPage };
@@ -602,18 +600,24 @@ function populateStatCollectionMenus() {
   });
 }
 
-// populates the tag menu with available tags
-function populateTagMenu(menu, callback) {
+function populateTagMenuWithValues (menu, tags) {
   menu.find('.menu').html('');
 
-  for (let tag of dbTags) {
+  for (let tag of tags) {
     menu.find('.menu').append('<div class="item" data-value="' + tag + '">' + tag + '</div>');
   }
 
   menu.dropdown('refresh');
+}
 
-  if (callback)
-    callback();
+// populates the tag menu with available tags
+function populateTagMenu(menu, callback) {
+  DB.getTags(function(tags) {
+    populateTagMenuWithValues(menu, tags)
+
+    if (callback)
+      callback();
+  });
 }
 
 function setAppCollection(value, text, $elem) {

--- a/js/index.js
+++ b/js/index.js
@@ -100,6 +100,8 @@ $.fn.datepicker.setDefaults({
 });
 
 var DB;
+var dbVersions;
+var dbTags;
 var sections = {};
 var prevSections = [];
 
@@ -167,23 +169,31 @@ function resumeInitApp() {
   setLoadMessage('Initializing Handlers');
   initGlobalUIHandlers();
 
-  // sections
-  setLoadMessage('Loading Sections');
-  loadSections();
-  $('.app-version-number').text(app.getVersion());
+  setLoadMessage('Retrieving versions');
+  DB.getVersions(function(versions) {
+    dbVersions = versions;
+    setLoadMessage('Retrieving tags');
+    DB.getTags(function(tags) {
+      dbTags = tags;
+      // sections
+      setLoadMessage('Loading Sections');
+      loadSections();
+      $('.app-version-number').text(app.getVersion());
 
-  // populate some menus
-  setLoadMessage('Populating Menus');
-  globalDBUpdate();
+      // populate some menus
+      setLoadMessage('Populating Menus');
+      globalDBUpdate();
 
-  $('.player-menu input.search').keyup(function(e) {
-    if (e.which === 38 || e.which === 40 || e.which === 13)
-      return;
+      $('.player-menu input.search').keyup(function(e) {
+        if (e.which === 38 || e.which === 40 || e.which === 13)
+          return;
 
-    updatePlayerMenuOptions(this, $(this).val());
+        updatePlayerMenuOptions(this, $(this).val());
+      });
+
+      removeLoader();
+    });
   });
-
-  removeLoader();
 }
 
 function loadDatabase() {
@@ -485,15 +495,13 @@ function addMapMenuOptions(menu) {
 }
 
 function addPatchMenuOptions(elem, callback) {
-  DB.getVersions(function(versions) {
-    elem.find('.menu').html('');
+  elem.find('.menu').html('');
 
-    for (let v in versions) {
-      elem.find('.menu').append('<div class="item" data-value="' + escapeHtml(v) + '">' + escapeHtml(versions[v]) + '</div>');
-    }
+  for (let v in dbVersions) {
+    elem.find('.menu').append('<div class="item" data-value="' + escapeHtml(v) + '">' + escapeHtml(dbVersions[v]) + '</div>');
+  }
 
-    callback();
-  });
+  callback();
 }
 
 function populateTeamMenu(elem) {
@@ -596,18 +604,16 @@ function populateStatCollectionMenus() {
 
 // populates the tag menu with available tags
 function populateTagMenu(menu, callback) {
-  DB.getTags(function(tags) {
-    menu.find('.menu').html('');
+  menu.find('.menu').html('');
 
-    for (let tag of tags) {
-      menu.find('.menu').append('<div class="item" data-value="' + tag + '">' + tag + '</div>');
-    }
+  for (let tag of dbTags) {
+    menu.find('.menu').append('<div class="item" data-value="' + tag + '">' + tag + '</div>');
+  }
 
-    menu.dropdown('refresh');
+  menu.dropdown('refresh');
 
-    if (callback)
-      callback();
-  });
+  if (callback)
+    callback();
 }
 
 function setAppCollection(value, text, $elem) {

--- a/js/maps.js
+++ b/js/maps.js
@@ -2,7 +2,7 @@ var mapsHeroDataFilter;
 var mapsMapDataFilter;
 var mapsMapRowTemplate;
 
-function initMapsPage() {
+function initMapsPage(tags) {
 
   // templates
   mapsMapRowTemplate = getHandlebars('maps', '#map-table-row-template');
@@ -22,7 +22,7 @@ function initMapsPage() {
   filterWidget.attr('widget-name', 'maps-filter');
 
   $('#filter-widget').append(filterWidget);
-  initPopup(filterWidget);
+  initPopup(filterWidget, tags);
 
   $('#maps-filter-button').popup({
     popup: '.filter-popup-widget[widget-name="maps-filter"]',

--- a/js/matches.js
+++ b/js/matches.js
@@ -22,7 +22,7 @@ var requireHeroOnTeam = false;
 var matchSearchQuery = {};
 var matchTeamActiveIDs = null;
 
-function initMatchesPage() {
+function initMatchesPage(tags) {
   // player menu init
   $('#match-search-players').dropdown({
     action: 'activate',
@@ -115,8 +115,8 @@ function initMatchesPage() {
     fullTextSearch: true
   });
 
-  populateTagMenu($('#matches-tags-popup .search.dropdown'));
-  populateTagMenu($('#match-search-tags'));
+  populateTagMenuWithValues($('#matches-tags-popup .search.dropdown'), tags);
+  populateTagMenuWithValues($('#match-search-tags'), tags);
 
   $('#matches-collection-select').modal();
 

--- a/js/player-ranking.js
+++ b/js/player-ranking.js
@@ -4,7 +4,7 @@ var playerRankingsMapFilter = {};
 
 var playerRankingTable;
 
-function initPlayerRankingPage() {
+function initPlayerRankingPage(tags) {
   // need to add the headers
   for (let c of TableDefs.PlayerRankingStatFormat.columns) {
     $('#player-ranking-general-table thead tr').append(`<th>${c.title}</th>`);
@@ -21,7 +21,7 @@ function initPlayerRankingPage() {
   filterWidget.find('.filter-widget-hero').addClass('is-hidden');
 
   $('#filter-widget').append(filterWidget);
-  initPopup(filterWidget);
+  initPopup(filterWidget, tags);
 
   bindFilterButton(filterWidget, updatePlayerRankingsFilter);
   bindFilterResetButton(filterWidget, resetPlayerRankingsFilter);

--- a/js/player.js
+++ b/js/player.js
@@ -215,7 +215,7 @@ heroPoolWinsGraphData = {
   }
 }
 
-function initPlayerPage() {
+function initPlayerPage(tags) {
   // player menu init
   let selectedPlayerID = settings.get('selectedPlayerID');
   let initOpt = '<div class="item" data-value="' + selectedPlayerID + '">' + selectedPlayerID + '</div>';
@@ -312,7 +312,7 @@ function initPlayerPage() {
   playerWidget.find('.filter-widget-team').addClass('is-hidden');
 
   $('#filter-widget').append(playerWidget);
-  initPopup(playerWidget);
+  initPopup(playerWidget, tags);
 
   bindFilterButton($('.filter-popup-widget[widget-name="player-filter"]'), updatePlayerFilter);
   bindFilterResetButton($('.filter-popup-widget[widget-name="player-filter"]'), resetPlayerFilter);

--- a/js/team-ranking.js
+++ b/js/team-ranking.js
@@ -6,7 +6,7 @@ var teamRankingHeroFilter = {};
 
 var teamRankingTable;
 
-function initTeamRankingPage() {
+function initTeamRankingPage(tags) {
   // populate headers
   for (let c of TableDefs.TeamRankingFormat.columns) {
     $('#team-ranking-general-table thead tr').append(`<th>${c.title}</th>`);
@@ -20,7 +20,7 @@ function initTeamRankingPage() {
   filterWidget.find('.filter-widget-team').addClass('is-hidden');
 
   $('#filter-widget').append(filterWidget);
-  initPopup(filterWidget);
+  initPopup(filterWidget, tags);
 
   bindFilterButton(filterWidget, updateTeamRankingFilter);
   bindFilterResetButton(filterWidget, resetTeamRankingsFilter);

--- a/js/teams.js
+++ b/js/teams.js
@@ -19,7 +19,7 @@ var teamTables = {
   pickDetail: null
 }
 
-function initTeamsPage() {
+function initTeamsPage(tags) {
   $('#team-set-team').dropdown({
     onChange: updateTeamData,
     fullTextSearch: true
@@ -54,7 +54,7 @@ function initTeamsPage() {
   filterWidget.find('.filter-widget-team').addClass('is-hidden');
 
   $('#filter-widget').append(filterWidget);
-  initPopup(filterWidget);
+  initPopup(filterWidget, tags);
 
   $('#team-filter-button').popup({
     popup: '.filter-popup-widget[widget-name="teams-filter"]',


### PR DESCRIPTION
I've been using Stats of the Storm for a while now and I've started to notice a bit of a slow down during startup. I have 2845 replays in the database and it takes 2m 13s to load. I suspected it might be database-related due to the number of replays so I instrumented all the database calls using [this code](https://github.com/rjnienaber/stats-of-the-storm/compare/master...instrument_database_calls).

This showed the following in the developer tools console:

```
2020-11-14T15:20:33.468Z Database.getDBVersion: 605ms
2020-11-14T15:20:35.587Z Database.getExternalCacheCollections: 2018ms
2020-11-14T15:20:35.594Z Database.getAllTeams: 823ms
2020-11-14T15:20:51.259Z Database.getVersions: 17458ms
2020-11-14T15:20:57.228Z Database.getTags: 23421ms
2020-11-14T15:21:03.256Z Database.getTags: 29448ms
2020-11-14T15:21:09.169Z Database.getVersions: 34743ms
2020-11-14T15:21:15.315Z Database.getTags: 40877ms
2020-11-14T15:21:21.232Z Database.getVersions: 46676ms
2020-11-14T15:21:27.311Z Database.getTags: 52743ms
2020-11-14T15:21:28.780Z Database.getMatches: 54187ms
2020-11-14T15:21:36.478Z Database.getVersions: 61744ms
2020-11-14T15:21:42.512Z Database.getTags: 67754ms
2020-11-14T15:21:48.409Z Database.getVersions: 73356ms
2020-11-14T15:21:54.389Z Database.getTags: 79325ms
2020-11-14T15:22:00.327Z Database.getVersions: 85077ms
2020-11-14T15:22:06.213Z Database.getTags: 90951ms
2020-11-14T15:22:12.006Z Database.getVersions: 96720ms
2020-11-14T15:22:17.681Z Database.getTags: 102381ms
2020-11-14T15:22:23.359Z Database.getVersions: 108028ms
2020-11-14T15:22:29.315Z Database.getTags: 113969ms
2020-11-14T15:22:35.199Z Database.getVersions: 119837ms
2020-11-14T15:22:40.836Z Database.getVersions: 125474ms
2020-11-14T15:22:41.324Z Database.getPlayers: 127514ms
2020-11-14T15:22:41.324Z Database.resolveMatchFilterAliases: 127514ms
2020-11-14T15:22:41.328Z Database.countMatches: 127518ms
2020-11-14T15:22:41.329Z Database.getPlayers: 127518ms
2020-11-14T15:22:41.329Z Database.resolveMatchFilterAliases: 127518ms
2020-11-14T15:22:41.333Z Database.countMatches: 127522ms
2020-11-14T15:22:41.343Z Database.getPlayers: 9ms
2020-11-14T15:22:41.343Z Database.resolveMatchFilterAliases: 9ms
2020-11-14T15:22:47.709Z Database.getMatchPage: 6375ms
```

I could see that there were some repeated calls to `getVersions` and `getTags`. Judging by the output, it also appeared that multiple calls were being issued to the database at the same time. Since LinvoDB is a file-backed database, I suspected that there may be some disk thrashing involved as it tries to serve multiple concurrent requests. 

This PR changes the calls to `getVersions` and `getTags` to be sequential and then cached. This seems to reduce the startup time on my machine to 43s. 

I think there is scope for other startup time improvements but I wanted to get your feedback on these changes before I attempt anything further. 