### PR TITLE
Add draft turns (bans and picks) to Hero Details export

### DIFF
--- a/js/exporters/hero-csv.js
+++ b/js/exporters/hero-csv.js
@@ -8,6 +8,7 @@ function heroDataCSV(docs) {
   // identifiers
   outData += 'ToonHandle';
   outData += ',name';
+  outData += ',turn';
   outData += ',hero';
   outData += ',date';
   outData += ',win';
@@ -41,6 +42,7 @@ function heroDataCSV(docs) {
     // identifiers
     row += doc.ToonHandle;
     row += ',' + doc.name;
+    row += ',' + doc.turn;
     row += ',' + doc.hero;
     row += ',' + doc.date;
     row += ',' + (doc.win ? 'true' : 'false');


### PR DESCRIPTION
This change is meant to include draft turns (bans and picks) in the CSV file with Hero Details.

I already made a pull request with the required changes to the parser being used in this project.