### PR TITLE
feat: add player's tag to players table

### DIFF
--- a/js/database/summarize-player-data.js
+++ b/js/database/summarize-player-data.js
@@ -32,6 +32,7 @@ function summarizePlayerData(docs, playerAliases = {}) {
     // set up the player object
     if (!(playerID in playerDetailStats)) {
       playerDetailStats[playerID] = {
+        tag: match.tag,
         games: 0,
         wins: 0,
         stats: {

--- a/js/player-ranking.js
+++ b/js/player-ranking.js
@@ -153,6 +153,7 @@ function loadPlayerRankings() {
 
         let context = player[mode];
         context.id = p;
+        context.tag = player.tag;
         context.name = player.name;
         context.wins = player.wins;
         context.winPercent = player.wins / player.games;

--- a/js/util/table-defs.js
+++ b/js/util/table-defs.js
@@ -431,6 +431,13 @@ function playerRankingStatFormat() {
       `<h3 class="ui inverted header player-name link-to-player" player-id="${row.id}">${data}</h4>`,
   };
 
+  const id = {
+    title: 'Tag',
+    data: 'tag',
+  };
+
+  base.columns.splice(1, 0, id);
+
   const wins = {
     title: 'Win %',
     data: 'winPercent',


### PR DESCRIPTION
By adding their tag, this PR allows for better clarity if two players have the same name.

![image](https://github.com/user-attachments/assets/5e8e9ddd-5acc-456e-9a9c-da898ec047a0)

note: this PR requires the tag fix for the hots-parser as well
https://github.com/ebshimizu/hots-parser/pull/65
Otherwise, the `hots-parser` tends to have incorrect tags if two players have the same `name` in a match.