### PR TITLE
fix: path separator for Linux compatibility in semantic.json

### DIFF
--- a/semantic.json
+++ b/semantic.json
@@ -1,5 +1,5 @@
 {
-  "base": "assets\\semantic",
+  "base": "assets/semantic",
   "paths": {
     "source": {
       "config": "src/theme.config",


### PR DESCRIPTION
This PR fixes Linux compatibility by using forward slashes rather than backslashes while ensuring that it does not break functionality on other platforms.

Note: on linux and mac, using `assets\\semantic` will actually create a file named `assets\semantic`, rather than putting it in that folder.  Therefore it breaks the build on those platforms.